### PR TITLE
修正网易歌单不能打开，如果搜索框内没有关键词，切换Tab时候不调用搜索接口

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -910,11 +910,16 @@
         $scope.loading = true;
         $scope.tab = newTab;
         $scope.result = [];
-        loWeb.get('/search?source=' + getSourceName($scope.tab) + '&keywords=' + $scope.keywords).success(function(data) {
-            // update the textarea
-            $scope.result = data.result;
-            $scope.loading = false;  
-        });
+
+        if ($scope.keywords===''){
+          $scope.loading = false;
+        }else{
+          loWeb.get('/search?source=' + getSourceName($scope.tab) + '&keywords=' + $scope.keywords).success(function(data) {
+              // update the textarea
+              $scope.result = data.result;
+              $scope.loading = false;
+          });
+        }
       };
 
       $scope.isActiveTab = function(tab){

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -40,22 +40,18 @@ var netease = (function() {
 
     var ne_get_playlist = function(url, hm, se) {
         var list_id = getParameterByName('list_id', url).split('_').pop();
-        var target_url = 'http://music.163.com/playlist?id=' + list_id;
+        var target_url = 'http://music.163.com/api/playlist/detail?id=' + list_id;
         return {
-            success: function(fn) {
-                hm.get(target_url).success(function(data) {
-                    data = $.parseHTML(data);
-                    var dataObj = $(data);
+            success: function (fn) {
+                hm.get(target_url).success(function (data) {
                     var info = {
                         'id': 'neplaylist_' + list_id,
-                        'cover_img_url': dataObj.find('.u-cover img').attr('src'),
-                        'title': dataObj.find('.tit h2').text(),
-                        'source_url': 'http://music.163.com/#/playlist?id=' + list_id,
+                        'cover_img_url': data.result.coverImgUrl,
+                        'title': data.result.name,
+                        'source_url': 'http://music.163.com/#/playlist?id=' + list_id
                     };
                     var tracks = [];
-                    var json_string = dataObj.find('textarea').val();
-                    var track_json_list = JSON.parse(json_string);
-                    $.each(track_json_list, function(index, track_json){
+                    $.each(data.result.tracks, function(index, track_json){
                         var default_track = {
                             'id': '0',
                             'title': '',


### PR DESCRIPTION
1. 26日起网易不能打开歌单，修正此问题
2. 如果搜索框内没有关键词，切换Tab时候不调用搜索接口