### PR TITLE
页面标题中播放图标根据播放状态而改变

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -693,6 +693,12 @@
       });
 
       $scope.$on('music:isPlaying', function(event, data) {
+        if (data) {
+          $rootScope.page_title = '▶' + $rootScope.page_title.slice(1);
+        }
+        else {
+          $rootScope.page_title = '⏸' + $rootScope.page_title.slice(1);
+        };
         if (!lastfm.isAuthorized()) {
           return;
         }


### PR DESCRIPTION
强迫症修复暂停时页面标题中播放图标不会改变的问题。这样一来标签页处于后台时通过标题中的图标可以方便地看到播放状态。