### PR TITLE
增加搜索分页等

### DIFF
--- a/css/player.css
+++ b/css/player.css
@@ -1041,3 +1041,77 @@ li {
 .settings-content {
     padding: 20px;
 }
+
+.lyric-content .lyric {
+   text-align: center;
+    width: 100%;
+    display: inline-block;
+    height: calc(100vh - 200px);
+    overflow-y: scroll;
+    position: relative;
+}
+
+.lyric-content .lyric::-webkit-scrollbar{
+  width: 7px;
+  height: 7px;
+  border-radius: 4px;
+  background-color: #333;
+  display: none;
+}
+
+.m-playbar .menu .lyric p,.lyric-content .lyric p{
+    min-height: 20px;
+    font-size: 16px;
+}
+
+.m-playbar .menu .lyric .placeholder,.lyric-content .lyric .placeholder{
+    height: 50px;
+}
+
+.m-playbar .menu .lyric .highlight,.lyric-content .lyric .highlight{
+    font-size: 15px;
+    color: #ff0000;
+}
+
+.lyric-content .lyric::-webkit-scrollbar{
+  width: 7px;
+  height: 7px;
+  border-radius: 4px;
+  background-color: #333;
+  display: none;
+}
+
+.btn-group button,.btn-pagination,.btn-pagination:focus {
+    background-color: #333333;
+    color: #ffffff;
+    border-color: #333333;
+}
+
+.btn-group button:hover,.btn-pagination:hover {
+    background-color: #ffffff!important;
+    color: #333333!important;
+}
+
+.searchbox  li>a:hover{
+color: #333333!important;
+}
+
+::-webkit-scrollbar{
+  width: 5px;
+  height: 7px;
+  border-radius: 3px;
+  background-color: #333;
+}
+::-webkit-scrollbar-button{
+  display: none;
+}
+::-webkit-scrollbar-track-piece {
+  display: none;
+}
+::-webkit-scrollbar-thumb{
+  background-color: #fff;
+  border-radius: 4px;
+}
+::-webkit-scrollbar-corner {
+  display: none;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -971,6 +971,8 @@
 
       var timeout;
       $scope.$watch('keywords', function (tmpStr,oldStr) {
+        updateCurrentPage(-1);
+        updateTotalPage(-1);
         if (!tmpStr || tmpStr.length === 0){
           $scope.result = [];
           return 0;
@@ -983,8 +985,6 @@
             $timeout.cancel(timeout);
           } 
           timeout = $timeout(function(){
-              updateCurrentPage(-1);
-              updateTotalPage(-1)
               performSearch();
           },500)
         }

--- a/js/app.js
+++ b/js/app.js
@@ -1035,7 +1035,7 @@
     app.directive('pagination',function(){
       return {
         restrict: "EA",
-        replace:true,
+        replace:false,
         template: ' <button class="btn btn-sm btn-pagination" ng-click="previousPage()" ng-disabled="curpage==1"> 上一页</button>\
        <label> {{curpage}}/{{totalpage}} 页 </label>\
        <button class="btn btn-sm btn-pagination" ng-click="nextPage()" ng-disabled="curpage==totalpage"> 下一页</button>',

--- a/js/app.js
+++ b/js/app.js
@@ -107,10 +107,20 @@
 
     $scope.lastfm = lastfm;
     
+    $scope.lyricArray = [];
+    $scope.lyricLineNumber= -1;
+
     $scope.$on('isdoubanlogin:update', function(event, data) {
       $scope.isDoubanLogin = data;
     });
 
+    $scope.$on('updateLyric', function(event, data) {
+      $scope.lyricArray = data;
+    });
+
+    $scope.$on('lyricLineNumber', function(event, data) {
+      $scope.lyricLineNumber = data;
+    });
     // tag
     $scope.showTag = function(tag_id){
       $scope.current_tag = tag_id;
@@ -825,6 +835,7 @@
             return;
           }
           $scope.lyricArray = parseLyric(lyric);
+          $scope.$emit("updateLyric", $scope.lyricArray);
         });
         $scope.lastTrackId = data;
       });
@@ -842,11 +853,18 @@
         }
         if (lastObject && lastObject.lineNumber != $scope.lyricLineNumber) {
           var lineHeight = 20;
-          var lineElement = $(".lyric p")[lastObject.lineNumber];
+          var lineElement = $(".menu .lyric p")[lastObject.lineNumber];
           var windowHeight = 270;
           var offset = lineElement.offsetTop - windowHeight/2;
-          $(".lyric").animate({ scrollTop: offset+"px" }, 500);
+          $(".menu .lyric").animate({ scrollTop: offset+"px" }, 500);
           $scope.lyricLineNumber = lastObject.lineNumber;
+
+          // 当前歌词Tab中的歌词联动
+          var lineElementTab = $(".lyric-content .lyric p")[lastObject.lineNumber];
+          var windowHeightTab = $(".lyric-content .lyric").height();
+          var offsetTab = lineElementTab.offsetTop - windowHeightTab/2;
+          $(".lyric-content .lyric").animate({ scrollTop: offsetTab+100+"px" }, 500);
+          $scope.$emit("lyricLineNumber",lastObject.lineNumber);
         }
       });
 
@@ -928,20 +946,22 @@
       $scope.tab = 0;
       $scope.keywords = '';
       $scope.loading = false;
+      $scope.curpagelog = [1,1,1];  // [网易,虾米,QQ]
+      $scope.totalpagelog = [1,1,1]; 
+      $scope.curpage = 1;
+      $scope.totalpage = 1;
 
       $scope.changeTab = function(newTab){
         $scope.loading = true;
         $scope.tab = newTab;
         $scope.result = [];
+        updateCurrentPage();
+        updateTotalPage();
 
         if ($scope.keywords===''){
-          $scope.loading = false;
+            $scope.loading = false;
         }else{
-          loWeb.get('/search?source=' + getSourceName($scope.tab) + '&keywords=' + $scope.keywords).success(function(data) {
-              // update the textarea
-              $scope.result = data.result;
-              $scope.loading = false;
-          });
+            performSearch();
         }
       };
 
@@ -949,24 +969,81 @@
         return $scope.tab === tab;
       };
 
-      $scope.$watch('keywords', function (tmpStr) {
+      var timeout;
+      $scope.$watch('keywords', function (tmpStr,oldStr) {
         if (!tmpStr || tmpStr.length === 0){
           $scope.result = [];
           return 0;
         }
-        // if searchStr is still the same..
+        // if searchStr changed and no more changes within 500ms ..
         // go ahead and retrieve the data
-        if (tmpStr === $scope.keywords)
+        if (tmpStr != oldStr)
         { 
-          $scope.loading = true;
-          loWeb.get('/search?source=' + getSourceName($scope.tab) + '&keywords=' + $scope.keywords).success(function(data) {
-            // update the textarea
-            $scope.result = data.result;
-            $scope.loading = false; 
-          });
+          if(timeout){
+            $timeout.cancel(timeout);
+          } 
+          timeout = $timeout(function(){
+              updateCurrentPage(-1);
+              updateTotalPage(-1)
+              performSearch();
+          },500)
         }
-      });
+      },true);
+
+      function performSearch(){
+        loWeb.get('/search?source=' + getSourceName($scope.tab) + '&keywords=' + $scope.keywords+'&curpage='+ $scope.curpage).success(function(data) {
+          // update the textarea
+          $scope.result = data.result;
+          updateTotalPage(data.total);
+          $scope.loading = false;
+        });
+      }
+
+      function updateCurrentPage(cp){
+          if(cp === -1){  // when search words changes,pagenums should be reset.
+              $scope.curpagelog = [1,1,1];
+              $scope.curpage = 1;
+          } 
+          else if(cp >= 0)
+              $scope.curpage = $scope.curpagelog[$scope.tab] = cp;
+          else  // only tab changed
+              $scope.curpage = $scope.curpagelog[$scope.tab];
+      }
+
+      function updateTotalPage(totalItem){
+          if(totalItem === -1) {
+              $scope.totalpagelog = [1,1,1];
+              $scope.totalpage = 1;
+          }
+          else if(totalItem >=0)
+            $scope.totalpage=$scope.totalpagelog[$scope.tab] = Math.ceil(totalItem/20);
+          else  
+              $scope.totalpage=$scope.totalpagelog[$scope.tab];
+      }
+
+      $scope.nextPage = function(){
+        $scope.curpage = $scope.curpagelog[$scope.tab] += 1;
+        performSearch();
+      }
+
+      $scope.previousPage = function(){
+          $scope.curpage = $scope.curpagelog[$scope.tab] -= 1;
+          performSearch();
+      }
   }]);
+
+    app.directive('pagination',function(){
+      return {
+        restrict: "EA",
+        replace:true,
+        template: ' <button class="btn btn-sm btn-pagination" ng-click="previousPage()" ng-disabled="curpage==1"> 上一页</button>\
+       <label> {{curpage}}/{{totalpage}} 页 </label>\
+       <button class="btn btn-sm btn-pagination" ng-click="nextPage()" ng-disabled="curpage==totalpage"> 下一页</button>',
+        replace: false,
+        link: function(scope, element, attrs) {
+      }
+    }
+  })
 
   app.directive('errSrc', function() {
     // http://stackoverflow.com/questions/16310298/if-a-ngsrc-path-resolves-to-a-404-is-there-a-way-to-fallback-to-a-default

--- a/js/app.js
+++ b/js/app.js
@@ -959,7 +959,7 @@
         updateTotalPage();
 
         if ($scope.keywords===''){
-            $scope.loading = false;
+           $scope.loading = false;
         }else{
             performSearch();
         }
@@ -1039,9 +1039,6 @@
         template: ' <button class="btn btn-sm btn-pagination" ng-click="previousPage()" ng-disabled="curpage==1"> 上一页</button>\
        <label> {{curpage}}/{{totalpage}} 页 </label>\
        <button class="btn btn-sm btn-pagination" ng-click="nextPage()" ng-disabled="curpage==totalpage"> 下一页</button>',
-        replace: false,
-        link: function(scope, element, attrs) {
-      }
     }
   })
 

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -212,9 +212,10 @@ var netease = (function() {
         // use chrome extension to modify referer.
         var target_url = 'http://music.163.com/api/search/pc';
         var keyword = getParameterByName('keywords', url);
+        var curpage = getParameterByName('curpage', url);
         var req_data = {
             's': keyword,
-            'offset': 0,
+            'offset': 20*(+curpage-1),
             'limit': 20,
             'type': 1
         };
@@ -250,7 +251,7 @@ var netease = (function() {
                         }
                         tracks.push(default_track);
                     });
-                    return fn({"result":tracks});
+                    return fn({"result":tracks,"total":data.result.songCount});
                 });
             }
         };

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -210,7 +210,7 @@ var netease = (function() {
     
     var ne_search = function(url, hm, se) {
         // use chrome extension to modify referer.
-        var target_url = 'http://music.163.com/api/search/pc';
+        var target_url = 'http://music.163.com/api/search/get';
         var keyword = getParameterByName('keywords', url);
         var curpage = getParameterByName('curpage', url);
         var req_data = {

--- a/js/provider/qq.js
+++ b/js/provider/qq.js
@@ -205,11 +205,12 @@ var qq = (function() {
         return {
             success: function(fn) {
                 var keyword = getParameterByName('keywords', url);
+                var curpage = getParameterByName('curpage', url);
                 var target_url = 'http://i.y.qq.com/s.music/fcgi-bin/search_for_qq_cp?' + 
                 'g_tk=938407465&uin=0&format=jsonp&inCharset=utf-8' + 
                 '&outCharset=utf-8&notice=0&platform=h5&needNewCode=1' + 
                 '&w=' + keyword + '&zhidaqu=1&catZhida=1' + 
-                '&t=0&flag=1&ie=utf-8&sem=1&aggr=0&perpage=20&n=20&p=1' + 
+                '&t=0&flag=1&ie=utf-8&sem=1&aggr=0&perpage=20&n=20&p=' + curpage + 
                 '&remoteplace=txt.mqq.all&_=1459991037831&jsonpCallback=jsonp4';
                 hm({
                     url:target_url,
@@ -224,7 +225,7 @@ var qq = (function() {
                         var track = qq_convert_song(item);
                         tracks.push(track);
                     });
-                    return fn({"result":tracks});
+                    return fn({"result":tracks,"total":data.data.song.totalnum});
                 });
             }
         };

--- a/js/provider/xiami.js
+++ b/js/provider/xiami.js
@@ -139,7 +139,8 @@ var xiami = (function() {
         return {
             success: function(fn) {
                 var keyword = getParameterByName('keywords', url);
-                var target_url = 'http://api.xiami.com/web?v=2.0&app_key=1&key=' + keyword + '&page=1&limit=50&callback=jsonp154&r=search/songs';
+                var curpage = getParameterByName('curpage', url);
+                var target_url = 'http://api.xiami.com/web?v=2.0&app_key=1&key=' + keyword + '&page='+ curpage +'&limit=20&callback=jsonp154&r=search/songs';
                 hm({
                     url:target_url,
                     method: 'GET',
@@ -153,7 +154,7 @@ var xiami = (function() {
                         var track = xm_convert_song(item, 'artist_name');
                         tracks.push(track);
                     });
-                    return fn({"result":tracks});
+                    return fn({"result":tracks,"total":data.data.total});
                 });
             }
         };

--- a/listen1.html
+++ b/listen1.html
@@ -136,7 +136,8 @@
             <li ng-class="{ 'active':current_tag==2 }"><a ng-click="showTag(2)">精选歌单</a></li>
             <li ng-class="{ 'active':current_tag==1 }"><a ng-click="showTag(1)">我的歌单</a></li>
             <li ng-class="{ 'active':current_tag==3 }"><a ng-click="showTag(3)">快速搜索</a></li>
-            <li ng-class="{ 'active':current_tag==4 }"><a ng-click="showTag(4)">关于</a></li>
+            <li ng-class="{ 'active':current_tag==4 }"><a ng-click="showTag(4)">当前歌词</a></li>
+            <li ng-class="{ 'active':current_tag==5 }"><a ng-click="showTag(5)">关于</a></li>
           </ul>
         </nav>
       </div>
@@ -232,12 +233,11 @@
             <ul class="detail-songlist">
               <li ng-repeat="song in result" ng-class-odd="'odd'" ng-class-even="'even'" ng-mouseenter="options=true" ng-mouseleave="options=false">
                   <div class="col2">
-                    <a ng-if="song.disabled" class="disabled" ng-click="copyrightNotice()">{{ song.title }}</a>
-                    <a ng-if="!song.disabled" add-and-play="song">{{ song.title }}</a>
+                    <a ng-if="song.disabled" class="disabled" ng-click="copyrightNotice()">{{ song.title |limitTo:30}}</a>
+                    <a ng-if="!song.disabled" add-and-play="song">{{ song.title |limitTo:30}}</a>
                   </div>
-                  <div class="col1 detail-artist"><a ng-click="showPlaylist(song.artist_id)">{{ song.artist }}</a></div>
-                  <div class="col2"><a ng-click="showPlaylist(song.album_id)">{{ song.album }}</a></div>
-                  
+                  <div class="col1 detail-artist"><a ng-click="showPlaylist(song.artist_id)">{{ song.artist |limitTo:20}}</a></div>
+                  <div class="col2"><a ng-click="showPlaylist(song.album_id)">{{ song.album |limitTo:30}}</a></div>
                   <div class="detail-tools">
                     <a title="添加到当前播放" class="detail-add-button" add-without-play="song" ng-show="options"></a>
                     <a title="添加到歌单" class="detail-fav-button" ng-show="options" ng-click="showDialog(0, song)"></a>
@@ -245,14 +245,29 @@
                   </div>
               </li>
             </ul>
+            <pagination ng-show= "totalpage>1"></pagination>
           </div>
         </div>
       </div>
     </div>
 
+    <!-- content page: 歌词 -->
+    <div class="site-wrapper" ng-show="current_tag==4">
+      <div class="site-wrapper-innerd" resize>
+        <div class="cover-container">
+        <div class="lyric-content">
+          <div class="lyric">
+               <div class="placeholder"></div>
+               <p ng-repeat="line in lyricArray track by $index" ng-class="{ 'highlight': line.lineNumber == lyricLineNumber }" >{{ line.content }} </p>
+               <div style="placeholder"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <!-- content page: 设置 -->
-    <div class="site-wrapper" ng-show="current_tag==4" ng-init="lastfm.updateStatus()">
+    <div class="site-wrapper" ng-show="current_tag==5" ng-init="lastfm.updateStatus()">
       <div class="site-wrapper-innerd" resize>
         <div class="cover-container">
          <!--  <div class="settings-title"><span>第三方登录<span></div>


### PR DESCRIPTION
### 1. ~~发现网易搜索结果不对了~~(后来发现用http://music.163.com/api/search/pc 和 http://music.163.com/api/search/get 都可以，挂着vpn导致搜索结果不对)。
### 2.增加了搜索翻页支持。
### 3.增加了歌词Tab,看歌词更爽。
### 4.滚动条美化了下，限制了搜索结果列表中歌名显示长度，有的歌名谜之长，占好几行。
#### 5.另想把 “歌单来源切换” 放到顶部，这样用窗口模式打开看起来特别赞，征求下po主意见，暂时没加到这个pr里，而且新增的 “打开歌单” 放在边上看起来有点强迫症难受。
![预览图](http://pasteupload.com/images/2017/07/13/Screenshotfrom2017-07-1316-48-16.png)