### PR TITLE
添加快速搜索分页、添加歌词Tab等

### DIFF
--- a/css/player.css
+++ b/css/player.css
@@ -1041,3 +1041,77 @@ li {
 .settings-content {
     padding: 20px;
 }
+
+.lyric-content .lyric {
+   text-align: center;
+    width: 100%;
+    display: inline-block;
+    height: calc(100vh - 200px);
+    overflow-y: scroll;
+    position: relative;
+}
+
+.lyric-content .lyric::-webkit-scrollbar{
+  width: 7px;
+  height: 7px;
+  border-radius: 4px;
+  background-color: #333;
+  display: none;
+}
+
+.m-playbar .menu .lyric p,.lyric-content .lyric p{
+    min-height: 20px;
+    font-size: 16px;
+}
+
+.m-playbar .menu .lyric .placeholder,.lyric-content .lyric .placeholder{
+    height: 50px;
+}
+
+.m-playbar .menu .lyric .highlight,.lyric-content .lyric .highlight{
+    font-size: 15px;
+    color: #ff0000;
+}
+
+.lyric-content .lyric::-webkit-scrollbar{
+  width: 7px;
+  height: 7px;
+  border-radius: 4px;
+  background-color: #333;
+  display: none;
+}
+
+.btn-group button,.btn-pagination,.btn-pagination:focus {
+    background-color: #333333;
+    color: #ffffff;
+    border-color: #333333;
+}
+
+.btn-group button:hover,.btn-pagination:hover {
+    background-color: #ffffff!important;
+    color: #333333!important;
+}
+
+.searchbox  li>a:hover{
+color: #333333!important;
+}
+
+::-webkit-scrollbar{
+  width: 5px;
+  height: 7px;
+  border-radius: 3px;
+  background-color: #333;
+}
+::-webkit-scrollbar-button{
+  display: none;
+}
+::-webkit-scrollbar-track-piece {
+  display: none;
+}
+::-webkit-scrollbar-thumb{
+  background-color: #fff;
+  border-radius: 4px;
+}
+::-webkit-scrollbar-corner {
+  display: none;
+}

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -212,9 +212,10 @@ var netease = (function() {
         // use chrome extension to modify referer.
         var target_url = 'http://music.163.com/api/search/pc';
         var keyword = getParameterByName('keywords', url);
+        var curpage = getParameterByName('curpage', url);
         var req_data = {
             's': keyword,
-            'offset': 0,
+            'offset': 20*(+curpage-1),
             'limit': 20,
             'type': 1
         };
@@ -250,7 +251,7 @@ var netease = (function() {
                         }
                         tracks.push(default_track);
                     });
-                    return fn({"result":tracks});
+                    return fn({"result":tracks,"total":data.result.songCount});
                 });
             }
         };
@@ -412,4 +413,3 @@ return {
 };
 
 })();
-

--- a/js/provider/qq.js
+++ b/js/provider/qq.js
@@ -205,11 +205,12 @@ var qq = (function() {
         return {
             success: function(fn) {
                 var keyword = getParameterByName('keywords', url);
+                var curpage = getParameterByName('curpage', url);
                 var target_url = 'http://i.y.qq.com/s.music/fcgi-bin/search_for_qq_cp?' + 
                 'g_tk=938407465&uin=0&format=jsonp&inCharset=utf-8' + 
                 '&outCharset=utf-8&notice=0&platform=h5&needNewCode=1' + 
                 '&w=' + keyword + '&zhidaqu=1&catZhida=1' + 
-                '&t=0&flag=1&ie=utf-8&sem=1&aggr=0&perpage=20&n=20&p=1' + 
+                '&t=0&flag=1&ie=utf-8&sem=1&aggr=0&perpage=20&n=20&p=' + curpage + 
                 '&remoteplace=txt.mqq.all&_=1459991037831&jsonpCallback=jsonp4';
                 hm({
                     url:target_url,
@@ -224,7 +225,7 @@ var qq = (function() {
                         var track = qq_convert_song(item);
                         tracks.push(track);
                     });
-                    return fn({"result":tracks});
+                    return fn({"result":tracks,"total":data.data.song.totalnum});
                 });
             }
         };

--- a/js/provider/xiami.js
+++ b/js/provider/xiami.js
@@ -139,7 +139,8 @@ var xiami = (function() {
         return {
             success: function(fn) {
                 var keyword = getParameterByName('keywords', url);
-                var target_url = 'http://api.xiami.com/web?v=2.0&app_key=1&key=' + keyword + '&page=1&limit=50&callback=jsonp154&r=search/songs';
+                var curpage = getParameterByName('curpage', url);
+                var target_url = 'http://api.xiami.com/web?v=2.0&app_key=1&key=' + keyword + '&page='+ curpage +'&limit=20&callback=jsonp154&r=search/songs';
                 hm({
                     url:target_url,
                     method: 'GET',
@@ -153,7 +154,7 @@ var xiami = (function() {
                         var track = xm_convert_song(item, 'artist_name');
                         tracks.push(track);
                     });
-                    return fn({"result":tracks});
+                    return fn({"result":tracks,"total":data.data.total});
                 });
             }
         };

--- a/listen1.html
+++ b/listen1.html
@@ -136,7 +136,8 @@
             <li ng-class="{ 'active':current_tag==2 }"><a ng-click="showTag(2)">精选歌单</a></li>
             <li ng-class="{ 'active':current_tag==1 }"><a ng-click="showTag(1)">我的歌单</a></li>
             <li ng-class="{ 'active':current_tag==3 }"><a ng-click="showTag(3)">快速搜索</a></li>
-            <li ng-class="{ 'active':current_tag==4 }"><a ng-click="showTag(4)">关于</a></li>
+            <li ng-class="{ 'active':current_tag==4 }"><a ng-click="showTag(4)">当前歌词</a></li>
+            <li ng-class="{ 'active':current_tag==5 }"><a ng-click="showTag(5)">关于</a></li>
           </ul>
         </nav>
       </div>
@@ -232,12 +233,11 @@
             <ul class="detail-songlist">
               <li ng-repeat="song in result" ng-class-odd="'odd'" ng-class-even="'even'" ng-mouseenter="options=true" ng-mouseleave="options=false">
                   <div class="col2">
-                    <a ng-if="song.disabled" class="disabled" ng-click="copyrightNotice()">{{ song.title }}</a>
-                    <a ng-if="!song.disabled" add-and-play="song">{{ song.title }}</a>
+                    <a ng-if="song.disabled" class="disabled" ng-click="copyrightNotice()">{{ song.title |limitTo:30}}</a>
+                    <a ng-if="!song.disabled" add-and-play="song">{{ song.title |limitTo:30}}</a>
                   </div>
-                  <div class="col1 detail-artist"><a ng-click="showPlaylist(song.artist_id)">{{ song.artist }}</a></div>
-                  <div class="col2"><a ng-click="showPlaylist(song.album_id)">{{ song.album }}</a></div>
-                  
+                  <div class="col1 detail-artist"><a ng-click="showPlaylist(song.artist_id)">{{ song.artist |limitTo:20}}</a></div>
+                  <div class="col2"><a ng-click="showPlaylist(song.album_id)">{{ song.album |limitTo:30}}</a></div>
                   <div class="detail-tools">
                     <a title="添加到当前播放" class="detail-add-button" add-without-play="song" ng-show="options"></a>
                     <a title="添加到歌单" class="detail-fav-button" ng-show="options" ng-click="showDialog(0, song)"></a>
@@ -245,14 +245,29 @@
                   </div>
               </li>
             </ul>
+            <pagination ng-show= "totalpage>1"></pagination>
           </div>
         </div>
       </div>
     </div>
 
+    <!-- content page: 歌词 -->
+    <div class="site-wrapper" ng-show="current_tag==4">
+      <div class="site-wrapper-innerd" resize>
+        <div class="cover-container">
+        <div class="lyric-content">
+          <div class="lyric">
+               <div class="placeholder"></div>
+               <p ng-repeat="line in lyricArray track by $index" ng-class="{ 'highlight': line.lineNumber == lyricLineNumber }" >{{ line.content }} </p>
+               <div style="placeholder"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
 
     <!-- content page: 设置 -->
-    <div class="site-wrapper" ng-show="current_tag==4" ng-init="lastfm.updateStatus()">
+    <div class="site-wrapper" ng-show="current_tag==5" ng-init="lastfm.updateStatus()">
       <div class="site-wrapper-innerd" resize>
         <div class="cover-container">
          <!--  <div class="settings-title"><span>第三方登录<span></div>


### PR DESCRIPTION
### 1 增加了搜索结果分页
### 2 增加了歌词面板，与原来播放列表旁的歌词同步滚动
### 3 修改了滚动条样式，更美观
### 4 另外有个想法，想把 “歌单来源” 切换按钮 以及 新增的 “打开歌单” 按钮放到顶部，这样用窗口模式打开时很整齐，比较好看，征求下po主意见。效果如下图，没在这个PR里
## **已知问题： 网易云音乐快速搜索翻页时，原本最后一页应该不足limit =20 时，有时也会返回20条结果，同时搜索结果页数会增加，例如本来搜索结果共有10页，翻到第10页突然总数变成30页，再翻页可能又会有新变化，应该是接口问题，感觉不值得专门增加代码解决就没管，除了网易翻到最后一页可能会有搜索总页数会变化没有其他影响**
[![Screenshotfrom2017-07-1316-48-16.md.png](http://pasteupload.com/images/2017/07/13/Screenshotfrom2017-07-1316-48-16.md.png)](http://pasteupload.com/image/NEQu)