### PR TITLE
同步歌单到个人Gist

### DIFF
--- a/js/gist.js
+++ b/js/gist.js
@@ -1,0 +1,67 @@
+(function() {
+  'use strict';
+  Storage.prototype.setObject = function(key, value) {
+    this.setItem(key, JSON.stringify(value));
+  }
+
+  Storage.prototype.getObject = function(key) {
+    var value = this.getItem(key);
+    return value && JSON.parse(value);
+  }
+
+  angular.module('gistClient', [])
+    .provider('gist', {
+      $get: function($http, $q) {
+        var apiUrl = 'https://api.github.com/gists/';
+
+        function _getGistInfo() {
+          return localStorage.getObject("gistinfo");
+        }
+
+        function backup(filecontent) {
+          var deferred = $q.defer();
+          $http({
+            method:'PATCH',
+            url:apiUrl + _getGistInfo().id,
+            headers:{'Authorization':'token ' + localStorage.getObject("gistinfo").token},
+            data:{
+            "description": "updated by Listen1(http://listen1.github.io/listen1/) at " + new Date().toLocaleString(),
+            "files": {
+              "listen1_backup.json": {
+              "content": filecontent
+                }
+              }
+            }
+          }).then(function(res) {
+            deferred.resolve();
+          }, function(err) {
+            deferred.reject(err)
+          });
+          return deferred.promise;
+        }
+
+        function restore() {
+          var deferred = $q.defer();
+          $http({
+            method:'GET',
+            url:apiUrl + _getGistInfo().id,
+          }).then(function(res) {
+            try{
+              var  backupcontent =  res.data.files["listen1_backup.json"].content;
+              deferred.resolve(backupcontent);
+            }catch(e){
+              deferred.reject(404);
+            }
+          }, function(err) {
+            deferred.reject(err);
+          });
+          return deferred.promise;
+        }
+        var gistApi = {
+          "backupMySettings2Gist": backup,
+          "importMySettingsFromGist": restore,
+        };
+        return gistApi;
+      }
+    })
+})();

--- a/listen1.html
+++ b/listen1.html
@@ -28,6 +28,7 @@
     <script type="text/javascript" src="js/vendor/timer.js"></script>
 
     <script type="text/javascript" src="js/lastfm.js"></script>
+    <script type="text/javascript" src="js/gist.js"></script>
 
     <script type="text/javascript" src="js/lowebutil.js"></script>
     <script type="text/javascript" src="js/provider/xiami.js"></script>
@@ -120,6 +121,20 @@
           </div>
 
           <button class="btn btn-primary confirm-button" ng-click="openUrl(dialog_url);closeDialog();">打开歌单</button>
+          <button class="btn btn-default" ng-click="closeDialog()">取消</button>
+        </div>
+
+        <!-- open playlist dialog -->
+        <div ng-show="dialog_type==6" class="dialog-open-url">
+          <div class="form-group">
+            <label >Gist id*</label>
+            <input type="text" class="form-control" placeholder="用于保存备份文件的gist id" ng-model="dialog_gistid"/>
+          </div>
+          <div class="form-group">
+            <label >Gist token</label>
+            <input type="text" class="form-control" placeholder="备份到Gist须提供token,仅还原可只填id" ng-model="dialog_gisttoken"/>
+          </div>
+          <button class="btn btn-primary confirm-button" ng-click="saveLocalGistInfo()">保存</button>
           <button class="btn btn-default" ng-click="closeDialog()">取消</button>
         </div>
 
@@ -266,6 +281,8 @@
             <p>重装插件或清除缓存数据会导致我的歌单数据丢失，强烈建议在这些操作前，备份我的歌单。</p>
             <div>
               <button class="btn btn-primary confirm-button" ng-click="backupMySettings()">下载备份文件</button>
+              <button class="btn btn-primary confirm-button" ng-click="backupMySettings2Gist()">备份到Gist</button>
+              <button class="btn btn-danger confirm-button" ng-click="clearLocalGistInfo()">清除Gist认证信息</button>
             </div>
           </div>
           <div class="settings-title"><span>数据恢复<span></div>
@@ -274,6 +291,7 @@
             <label class="btn btn-warning" for="my-file-selector">
               <input id="my-file-selector" type="file" style="display:none;" ng-model="myuploadfiles"  custom-on-change="importMySettings">上传备份文件
             </label>
+            <button class="btn btn-warning confirm-button" ng-click="importMySettingsFromGist()">从Gist恢复</button>
           </div>
           <div class="settings-title"><span>快捷键<span></div>
           <div class="settings-content">


### PR DESCRIPTION
### 1.通过提供Gist id 和 personal_token ，可将歌单备份到Gist，需要时可从Gist恢复，入口在关于页面，建议新生成一个仅包含gist权限的token用于此处。
### 2. 流程： 提供用于保存备份文件的gist_id -> 申请仅具有gist权限的token -> 随时备份歌单到Gist ->重装、换机、清空缓存等导致歌单丢失 -> 通过gist id一键还原歌单