### PR TITLE
修复 部分歌词符号显示不正确

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -910,7 +910,12 @@
           var timeReg = /\[(\d{2,})\:(\d{2})(?:\.(\d{1,3}))?\]/g;
 
           while(timeRegResult = timeReg.exec(line)) {
-            var content = line.replace(/\[(\d{2,})\:(\d{2})(?:\.(\d{1,3}))?\]/g, '');
+            var content = line.replace(/\[(\d{2,})\:(\d{2})(?:\.(\d{1,3}))?\]/g, '')
+              .replace(/&lt;/g, "<")
+              .replace(/&gt;/g, ">")
+              .replace(/&amp;/g, "&")
+              .replace(/&quot;/g, '"')
+              .replace(/&apos;/g, "'");
             var min = parseInt(timeRegResult[1]);
             var sec = parseInt(timeRegResult[2]);
             var microsec = 0;


### PR DESCRIPTION
部分歌曲在qq音乐下 歌词中会显示 `&apos;`.例如 <Rap God > -Eminem.
对这部分符号进行了处理.