### PR TITLE
修改专辑及艺人界面的封面固定高度、宽度自适应，歌词界面的封面居中自适应，避免图片被压缩变形。

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -355,8 +355,6 @@ svg {
 
 .page .playlist-detail .detail-head img {
   height: 150px;
-  width: 150px;
-  object-fit: cover;
 }
 
 .page .playlist-detail .detail-head .detail-head-cover {
@@ -779,7 +777,6 @@ svg.searchspinner {
 
 .footer .main-info .cover {
   height: 60px;
-  width: 60px;
   flex: 0 0 60px;
   cursor: pointer;
 }

--- a/css/common.css
+++ b/css/common.css
@@ -777,6 +777,8 @@ svg.searchspinner {
 
 .footer .main-info .cover {
   height: 60px;
+  width: 60px;
+  object-fit: cover;
   flex: 0 0 60px;
   cursor: pointer;
 }

--- a/css/common.css
+++ b/css/common.css
@@ -356,6 +356,7 @@ svg {
 .page .playlist-detail .detail-head img {
   height: 150px;
   width: 150px;
+  object-fit: cover;
 }
 
 .page .playlist-detail .detail-head .detail-head-cover {
@@ -529,6 +530,7 @@ svg {
 .page .playsong-detail .detail-head img {
   width: 250px;
   height: 250px;
+  object-fit: cover;
 }
 
 .page .playsong-detail .detail-songinfo {


### PR DESCRIPTION
源代码设置了在detail-head-cover设置了flex: 0 0 150px;我觉得是想实现高度固定，宽度自适应的吧。所以我尝试修改实现。但是浏览器来说自适应不大会影响布局，对桌面版的布局我没法去实验。。。
歌词界面的封面我觉得居中自适应比缩放长宽更好看些。
实验专辑：https://music.163.com/#/album?id=35178609
实验艺人：https://music.163.com/#/artist?id=900347
它的封面是长方形的。