### PR TITLE
修复虾米精选歌单因图片长宽不一导致的排列混乱

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -301,11 +301,15 @@ svg {
 }
 
 .playlist-covers .u-cover {
+  display:flex;
   position: relative;
 }
 
 .playlist-covers .u-cover img {
+  height: 136px;
   max-width: 100%;
+  object-fit: cover;
+  margin: auto;
   border: solid 1px var(--line-default-color);
   margin-bottom: 2px;
   cursor: pointer;

--- a/css/common.css
+++ b/css/common.css
@@ -306,7 +306,7 @@ svg {
 }
 
 .playlist-covers .u-cover img {
-  height: 136px;
+  height: 137px;
   max-width: 100%;
   object-fit: cover;
   margin: auto;


### PR DESCRIPTION
虾米的歌单封面大小不一，有横向的又有纵向的，导致精选歌单列表排列很混乱，修改为统一高度137，居中显示封面。