### PR TITLE
精选歌单图片增加最小宽度参数，歌单下部文字自适应高度，防止文字被遮挡

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -469,7 +469,6 @@ svg {
 
 .page .playlist-detail .detail-head .detail-head-title h2 {
   font-size: var(--h2-title-font-size);
-  min-height: 33px;
 }
 /* page playlist detail end */
 

--- a/css/common.css
+++ b/css/common.css
@@ -588,8 +588,8 @@ svg {
   flex: 0 0 380px;
   overflow-y: scroll;
   color: var(--lyric-default-color);
-  scrollbar-width: thin;
-  scrollbar-color: var(--scroll-color) var(--content-background-color);
+  scrollbar-width: auto;
+  scrollbar-color: var(--scroll-color) transparent;
   font-size: 14px;
 }
 .page .playsong-detail .detail-songinfo .lyric p {

--- a/css/common.css
+++ b/css/common.css
@@ -378,6 +378,7 @@ svg {
 
 .playlist-button-list {
   display: flex;
+  flex-flow: row wrap;
 }
 
 .playlist-button-list .playlist-button {
@@ -386,7 +387,7 @@ svg {
   cursor: pointer;
   border-radius: 2px;
   display: flex;
-  margin-right: 20px;
+  margin: 0 20px 20px 0;
 }
 
 .playlist-button-list .playlist-button.playadd-button {

--- a/css/common.css
+++ b/css/common.css
@@ -347,7 +347,7 @@ svg {
   cursor: pointer;
 }
 
-.playlist-covers .desc .ng-binding {
+.playlist-covers .desc .title {
   display: flex;
   min-height: 32px;
   margin: 0 0 5px;

--- a/css/common.css
+++ b/css/common.css
@@ -468,7 +468,7 @@ svg {
 
 .page .playlist-detail .detail-head .detail-head-title h2 {
   font-size: var(--h2-title-font-size);
-  height: 33px;
+  min-height: 33px;
 }
 /* page playlist detail end */
 

--- a/css/common.css
+++ b/css/common.css
@@ -348,7 +348,8 @@ svg {
 }
 
 .playlist-covers .desc .ng-binding {
-  display:flex;
+  display: flex;
+  min-height: 32px;
   margin: 0 0 5px;
 }
 /* page hot-playlist end */

--- a/css/common.css
+++ b/css/common.css
@@ -295,7 +295,7 @@ svg {
 
 .playlist-covers li {
   flex: 0 1 calc(20% - 26px);
-  height: 185px;
+  min-height: 156px;
   color: var(--text-default-color);
   margin: 0 13px;
 }
@@ -306,7 +306,8 @@ svg {
 }
 
 .playlist-covers .u-cover img {
-  height: 137px;
+  height: 136px;
+  min-width: 136px;
   max-width: 100%;
   object-fit: cover;
   margin: auto;
@@ -344,6 +345,11 @@ svg {
 
 .playlist-covers .desc {
   cursor: pointer;
+}
+
+.playlist-covers .desc .ng-binding {
+  display:flex;
+  margin: 0 0 5px;
 }
 /* page hot-playlist end */
 

--- a/listen1.html
+++ b/listen1.html
@@ -213,7 +213,7 @@
                                         <div class="u-cover"><img ng-src="{{i.cover_img_url}}" ng-click="showPlaylist(i.id)">
                                             <div class="bottom" ng-click="directplaylist(i.id)"><svg class="feather"><use xlink:href="images/feather-sprite.svg#play-circle"></use></svg></div>
                                         </div>
-                                        <div class="desc"><span ng-click="showPlaylist(i.id)">{{i.title}}</span></div>
+                                        <div class="desc"><span class="title" ng-click="showPlaylist(i.id)">{{i.title}}</span></div>
                                     </li>
                                     <div class="loading_bottom">  <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"  width="40px" height="40px" viewBox="0 0 40 40" enable-background="new 0 0 40 40" xml:space="preserve"> <path opacity="0.2" fill="#000" d="M20.201,5.169c-8.254,0-14.946,6.692-14.946,14.946c0,8.255,6.692,14.946,14.946,14.946 s14.946-6.691,14.946-14.946C35.146,11.861,28.455,5.169,20.201,5.169z M20.201,31.749c-6.425,0-11.634-5.208-11.634-11.634 c0-6.425,5.209-11.634,11.634-11.634c6.425,0,11.633,5.209,11.633,11.634C31.834,26.541,26.626,31.749,20.201,31.749z"/> <path fill="#000" d="M26.013,10.047l1.654-2.866c-2.198-1.272-4.743-2.012-7.466-2.012h0v3.312h0 C22.32,8.481,24.301,9.057,26.013,10.047z"> <animateTransform attributeType="xml" attributeName="transform"  type="rotate" from="0 20 20"  to="360 20 20" dur="0.6s" repeatCount="indefinite"/> </path> </svg></div>
                                 </ul>


### PR DESCRIPTION
精选歌单图片增加最小宽度参数，经过测试高度136，最小宽度136，排版后显示5列，观感比较合适，同时能满足缩放后的UI自适应。原来的高度137会导致只有4列。
同时下部歌单名字太长时文字会形成三行，会被图片遮挡，修改为自适应高度避免被遮挡。