### PR TITLE
修复网易云导入歌单大于1000首失败问题，更改音乐详情页背景图片

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -521,7 +521,27 @@ svg {
   stroke: var(--now-playing-close-icon-color);
 }
 
+.page .bg {
+  opacity: 0.5;
+  height: 100%;
+  text-align: center;
+  line-height: 100%;
+  float: left;
+  width: 100%;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+  -webkit-filter: blur(15px);
+  -moz-filter: blur(15px);
+  -o-filter: blur(15px);
+  -ms-filter: blur(15px);
+  filter: blur(15px);
+}
+
 .page .playsong-detail {
+  position:absolute;
+  left: 10px;
+  right: 10px;
   max-width: 770px;
   margin: 0 auto;
   display: flex;

--- a/css/iparanoid.css
+++ b/css/iparanoid.css
@@ -7,7 +7,7 @@
   --text-subtitle-color: #666666;
   --text-disable-color: #999999;
 
-  --lyric-default-color: #666666;
+  --lyric-default-color: #333333;
 
   --link-default-color: #999999;
   --link-highlight-color: #111111;

--- a/css/iparanoid.css
+++ b/css/iparanoid.css
@@ -34,7 +34,7 @@
 
   --window-control-border-color: #dddddd;
 
-  --important-color: #ff4444;
+  --important-color: #fff;
 
   --button-background-color: #eeeeee;
   --button-border-color: #bebebe;

--- a/css/origin.css
+++ b/css/origin.css
@@ -7,7 +7,7 @@
   --text-subtitle-color: #666666;
   --text-disable-color: #999999;
 
-  --lyric-default-color: #666666;
+  --lyric-default-color: #aaaaaa;
 
   --link-default-color: #999999;
   --link-highlight-color: #ffffff;

--- a/css/origin.css
+++ b/css/origin.css
@@ -7,7 +7,7 @@
   --text-subtitle-color: #666666;
   --text-disable-color: #999999;
 
-  --lyric-default-color: #aaaaaa;
+  --lyric-default-color: #bbbbbb;
 
   --link-default-color: #999999;
   --link-highlight-color: #ffffff;

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -205,55 +205,44 @@ function build_netease() {
   }
 
   function ng_parse_playlist_tracks(playlist_tracks, hm, se, callback) {
-    var list = playlist_tracks;
-    var count = Math.ceil(list.length / 1000);
-    var nowCount = 0;
-    var playList = [];
-    function ng_parse_playlist_tracks_getData(playlist_tracks, hm, se, callback, index) {
-        const target_url = 'https://music.163.com/weapi/v3/song/detail';
-        const track_ids = playlist_tracks.map(i => i.id);
-        const d = {
-            c: '[' + track_ids.map(id => ('{"id":' + id + '}')).join(',') + ']',
-            ids: '[' + track_ids.join(',') + ']'
-        }
-        const data = _encrypted_request(d);
-        hm({
-            url: target_url,
-            method: 'POST',
-            data: se(data),
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            },
-        }).then((response) => {
-            return callback(index, response.data.songs.map(track_json => ({
-                id: `netrack_${track_json.id}`,
-                title: track_json.name,
-                artist: track_json.ar[0].name,
-                artist_id: `neartist_${track_json.ar[0].id}`,
-                album: track_json.al.name,
-                album_id: `nealbum_${track_json.al.id}`,
-                source: 'netease',
-                source_url: `http://music.163.com/#/song?id=${track_json.id}`,
-                img_url: track_json.al.picUrl,
-                url: `netrack_${track_json.id}`,
-            })));
-        });
+    const target_url = 'https://music.163.com/weapi/v3/song/detail';
+    const track_ids = playlist_tracks.map(i=>i.id);
+    const d = {
+      c: '[' + track_ids.map(id => ('{"id":' + id + '}')).join(',') + ']',
+      ids: '[' + track_ids.join(',') + ']'
     }
-    function cb(index, data) {
-        nowCount++;
-        playList[index] = data;
-        if (count == nowCount) {
-            var _playList = [];
-            for (var i = 0; i < playList.length; i++) {
-                _playList = _playList.concat(playList[i]);
-            }
-            return callback(null, _playList);
-        }
-    }
+    const data = _encrypted_request(d);
+    hm({
+      url: target_url,
+      method: 'POST',
+      data: se(data),
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    }).then((response)=>{
+      const tracks = response.data.songs.map(track_json=>({
+        id: `netrack_${track_json.id}`,
+        title: track_json.name,
+        artist: track_json.ar[0].name,
+        artist_id: `neartist_${track_json.ar[0].id}`,
+        album: track_json.al.name,
+        album_id: `nealbum_${track_json.al.id}`,
+        source: 'netease',
+        source_url: `http://music.163.com/#/song?id=${track_json.id}`,
+        img_url: track_json.al.picUrl,
+        url: `netrack_${track_json.id}`,
+      }));
+
+      return callback(null, tracks);
+    });
+  }
+  function split_array(myarray, size) {
+    var count = Math.ceil(myarray.length / size);
+    var result = [];
     for (var i = 0; i < count; i++) {
-        playlist_tracks = list.slice(i * 1000, (i + 1) * 1000);
-        ng_parse_playlist_tracks_getData(playlist_tracks, hm, se, cb, i)
+      result.push(myarray.slice(i * size, (i + 1) * size));
     }
+    return result;
   }
 
   function ne_get_playlist(url, hm, se) {
@@ -288,13 +277,16 @@ function build_netease() {
               title: res_data.playlist.name,
               source_url: `http://music.163.com/#/playlist?id=${list_id}`,
             };
+            var max_allow_size = 1000;
+            var trackIdsArray = split_array(res_data.playlist.trackIds, max_allow_size);
 
-            // request all tracks to fetch song info
-            ng_parse_playlist_tracks(res_data.playlist.trackIds, hm, se,
-            (err, tracks) => fn({
-              tracks,
-              info,
-            }));
+            function ng_parse_playlist_tracks_wrapper(trackIds, callback){
+              return ng_parse_playlist_tracks(trackIds, hm, se, callback);
+            }
+
+            async.concat(trackIdsArray, ng_parse_playlist_tracks_wrapper, function(err, tracks){
+              fn({tracks, info});
+            });
 
             // request every tracks to fetch song info
             // async_process_list(res_data.playlist.trackIds, ng_render_playlist_result_item, [hm, se],

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -205,55 +205,36 @@ function build_netease() {
   }
 
   function ng_parse_playlist_tracks(playlist_tracks, hm, se, callback) {
-    var list = playlist_tracks;
-    var count = Math.ceil(list.length / 1000);
-    var nowCount = 0;
-    var playList = [];
-    function ng_parse_playlist_tracks_getData(playlist_tracks, hm, se, callback, index) {
-        const target_url = 'https://music.163.com/weapi/v3/song/detail';
-        const track_ids = playlist_tracks.map(i => i.id);
-        const d = {
-            c: '[' + track_ids.map(id => ('{"id":' + id + '}')).join(',') + ']',
-            ids: '[' + track_ids.join(',') + ']'
-        }
-        const data = _encrypted_request(d);
-        hm({
-            url: target_url,
-            method: 'POST',
-            data: se(data),
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            },
-        }).then((response) => {
-            return callback(index, response.data.songs.map(track_json => ({
-                id: `netrack_${track_json.id}`,
-                title: track_json.name,
-                artist: track_json.ar[0].name,
-                artist_id: `neartist_${track_json.ar[0].id}`,
-                album: track_json.al.name,
-                album_id: `nealbum_${track_json.al.id}`,
-                source: 'netease',
-                source_url: `http://music.163.com/#/song?id=${track_json.id}`,
-                img_url: track_json.al.picUrl,
-                url: `netrack_${track_json.id}`,
-            })));
-        });
+    const target_url = 'https://music.163.com/weapi/v3/song/detail';
+    const track_ids = playlist_tracks.map(i=>i.id);
+    const d = {
+      c: '[' + track_ids.map(id => ('{"id":' + id + '}')).join(',') + ']',
+      ids: '[' + track_ids.join(',') + ']'
     }
-    function cb(index, data) {
-        nowCount++;
-        playList[index] = data;
-        if (count == nowCount) {
-            var _playList = [];
-            for (var i = 0; i < playList.length; i++) {
-                _playList = _playList.concat(playList[i]);
-            }
-            return callback(null, _playList);
-        }
-    }
-    for (var i = 0; i < count; i++) {
-        playlist_tracks = list.slice(i * 1000, (i + 1) * 1000);
-        ng_parse_playlist_tracks_getData(playlist_tracks, hm, se, cb, i)
-    }
+    const data = _encrypted_request(d);
+    hm({
+      url: target_url,
+      method: 'POST',
+      data: se(data),
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    }).then((response)=>{
+      const tracks = response.data.songs.map(track_json=>({
+        id: `netrack_${track_json.id}`,
+        title: track_json.name,
+        artist: track_json.ar[0].name,
+        artist_id: `neartist_${track_json.ar[0].id}`,
+        album: track_json.al.name,
+        album_id: `nealbum_${track_json.al.id}`,
+        source: 'netease',
+        source_url: `http://music.163.com/#/song?id=${track_json.id}`,
+        img_url: track_json.al.picUrl,
+        url: `netrack_${track_json.id}`,
+      }));
+
+      return callback(null, tracks);
+    });
   }
 
   function ne_get_playlist(url, hm, se) {

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -205,36 +205,55 @@ function build_netease() {
   }
 
   function ng_parse_playlist_tracks(playlist_tracks, hm, se, callback) {
-    const target_url = 'https://music.163.com/weapi/v3/song/detail';
-    const track_ids = playlist_tracks.map(i=>i.id);
-    const d = {
-      c: '[' + track_ids.map(id => ('{"id":' + id + '}')).join(',') + ']',
-      ids: '[' + track_ids.join(',') + ']'
+    var list = playlist_tracks;
+    var count = Math.ceil(list.length / 1000);
+    var nowCount = 0;
+    var playList = [];
+    function ng_parse_playlist_tracks_getData(playlist_tracks, hm, se, callback, index) {
+        const target_url = 'https://music.163.com/weapi/v3/song/detail';
+        const track_ids = playlist_tracks.map(i => i.id);
+        const d = {
+            c: '[' + track_ids.map(id => ('{"id":' + id + '}')).join(',') + ']',
+            ids: '[' + track_ids.join(',') + ']'
+        }
+        const data = _encrypted_request(d);
+        hm({
+            url: target_url,
+            method: 'POST',
+            data: se(data),
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+        }).then((response) => {
+            return callback(index, response.data.songs.map(track_json => ({
+                id: `netrack_${track_json.id}`,
+                title: track_json.name,
+                artist: track_json.ar[0].name,
+                artist_id: `neartist_${track_json.ar[0].id}`,
+                album: track_json.al.name,
+                album_id: `nealbum_${track_json.al.id}`,
+                source: 'netease',
+                source_url: `http://music.163.com/#/song?id=${track_json.id}`,
+                img_url: track_json.al.picUrl,
+                url: `netrack_${track_json.id}`,
+            })));
+        });
     }
-    const data = _encrypted_request(d);
-    hm({
-      url: target_url,
-      method: 'POST',
-      data: se(data),
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-    }).then((response)=>{
-      const tracks = response.data.songs.map(track_json=>({
-        id: `netrack_${track_json.id}`,
-        title: track_json.name,
-        artist: track_json.ar[0].name,
-        artist_id: `neartist_${track_json.ar[0].id}`,
-        album: track_json.al.name,
-        album_id: `nealbum_${track_json.al.id}`,
-        source: 'netease',
-        source_url: `http://music.163.com/#/song?id=${track_json.id}`,
-        img_url: track_json.al.picUrl,
-        url: `netrack_${track_json.id}`,
-      }));
-
-      return callback(null, tracks);
-    });
+    function cb(index, data) {
+        nowCount++;
+        playList[index] = data;
+        if (count == nowCount) {
+            var _playList = [];
+            for (var i = 0; i < playList.length; i++) {
+                _playList = _playList.concat(playList[i]);
+            }
+            return callback(null, _playList);
+        }
+    }
+    for (var i = 0; i < count; i++) {
+        playlist_tracks = list.slice(i * 1000, (i + 1) * 1000);
+        ng_parse_playlist_tracks_getData(playlist_tracks, hm, se, cb, i)
+    }
   }
 
   function ne_get_playlist(url, hm, se) {

--- a/listen1.html
+++ b/listen1.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en" ng-app="listenone">
 
 <head>
@@ -421,20 +421,22 @@
                         </div>
                         <!-- now playing window-->
                         <div class="songdetail-wrapper" ng-class="{slidedown: window_type!=='track'}">
-                            <div class="close" ng-class="isMac? 'mac':'' "ng-click="popWindow()"><svg class="icon"><use xlink:href="images/feather-sprite.svg#chevron-down"></use></svg></div>
+                            <div class="bg" style="background-image: url({{ currentPlaying.img_url }});"></div>
+                            <div class="close" ng-class="isMac? 'mac':'' " ng-click="popWindow()"><svg class="icon"><use xlink:href="images/feather-sprite.svg#chevron-down"></use></svg></div>
 
                             <div ng-if="!isChrome && !isMac" class="window-control">
-                              <svg class="icon" window-control="window_min"><use xlink:href="images/feather-sprite.svg#minimize-2"></use></svg>
-                              <svg class="icon" window-control="window_max"><use xlink:href="images/feather-sprite.svg#maximize" ></use></svg>
-                              <svg class="icon" window-control="window_close"><use xlink:href="images/feather-sprite.svg#x"></use></svg>
+                                <svg class="icon" window-control="window_min"><use xlink:href="images/feather-sprite.svg#minimize-2"></use></svg>
+                                <svg class="icon" window-control="window_max"><use xlink:href="images/feather-sprite.svg#maximize"></use></svg>
+                                <svg class="icon" window-control="window_close"><use xlink:href="images/feather-sprite.svg#x"></use></svg>
                             </div>
 
                             <div class="playsong-detail">
                                 <div class="detail-head">
-                                    <div class="detail-head-cover"><img ng-src="{{ currentPlaying.img_url  }}" err-src="https://y.gtimg.cn/mediastyle/global/img/album_300.png"/></div>
+                                    <div class="detail-head-cover"><img ng-src="{{ currentPlaying.img_url  }}" err-src="https://y.gtimg.cn/mediastyle/global/img/album_300.png" /></div>
                                     <div class="detail-head-title">
                                         <!--<a title="加入收藏" class="clone" ng-click="showDialog(0, currentPlaying)">收藏</a>
-<a open-url="currentPlaying.source_url" title="原始链接" class="link">原始链接</a>--></div>
+                <a open-url="currentPlaying.source_url" title="原始链接" class="link">原始链接</a>-->
+                                    </div>
                                 </div>
                                 <div class="detail-songinfo">
                                     <h2>{{ currentPlaying.title }}</h2>


### PR DESCRIPTION
网易云音乐歌单超过1000首会失败，因传入id过多，数据包太大会被服务器拒绝数据。修改为拆分歌单，1000首发送一次请求获取，获取所有数据后再统一显示
具体内容可查看我的博客：[网易云音乐歌单过长无法导入](https://www.cnblogs.com/NBDWDYS2214143926/p/13384020.html)