### PR TITLE
虾米增加翻译歌词

### DIFF
--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -496,7 +496,8 @@ function build_netease() {
             lrc = res_data.lrc.lyric;
           }
           if (res_data.tlyric != null) {
-            tlrc = res_data.tlyric.lyric;
+            tlrc = res_data.tlyric.lyric.replace(/(|\\)/g, '');
+            tlrc = tlrc.replace(/[\u2005]+/g, ' ');
           }
           return fn({
             lyric: lrc,

--- a/js/provider/xiami.js
+++ b/js/provider/xiami.js
@@ -162,8 +162,9 @@ function build_xiami() {
   }
 
   function get_highest_quality(arr) {
-    var i = arr.length, max = -Infinity, url = '';
-    while (i--) {
+    var max = 0;
+    var url = "";
+    for (var i = 0; i < arr.length; i++) {
       if (arr[i].fileSize > max) {
         max = arr[i].fileSize;
         url = arr[i].listenFile;


### PR DESCRIPTION
虾米增加翻译歌词，并优化一些api端口
优化网易翻译显示（除参考代码里的方框字符外，还有隐藏看不见的<0x08>字符和‘\’）
参考部分代码：https://github.com/Konata09/ESLyric_netease