### PR TITLE
Add "front" player

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1088,7 +1088,7 @@ const main = () => {
 
         return result;
       }
-      const mode = 'background';
+      const mode = 'front';
       addPlayerListener(mode, (msg, sender, sendResponse) => {
         if (typeof msg.type === 'string' && msg.type.split(':')[0] === 'BG_PLAYER') {
           switch (msg.type.split(':').slice(1).join('')) {
@@ -1274,7 +1274,9 @@ const main = () => {
               break;
           }
         }
-        sendResponse();
+        if (sendResponse !== undefined) {
+          sendResponse();
+        }
       });
 
       // define keybind

--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-shadow */
 /* global l1Player localStorage document Blob navigator */
 /* global $ angular FileReader isElectron getAllProviders */
-/* global setPrototypeOfLocalStorage addPlayerLisnter */
+/* global setPrototypeOfLocalStorage addPlayerListener */
 /* eslint-disable global-require */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-param-reassign */
@@ -1089,7 +1089,7 @@ const main = () => {
         return result;
       }
       const mode = 'background';
-      addPlayerLisnter(mode, (msg, sender, sendResponse) => {
+      addPlayerListener(mode, (msg, sender, sendResponse) => {
         if (typeof msg.type === 'string' && msg.type.split(':')[0] === 'BG_PLAYER') {
           switch (msg.type.split(':').slice(1).join('')) {
             case 'READY': {

--- a/js/app.js
+++ b/js/app.js
@@ -861,7 +861,7 @@ const main = () => {
               });
             });
           }).catch((err) => {
-            console.log(err);
+            // console.log(err);
           });
         }
       };

--- a/js/app.js
+++ b/js/app.js
@@ -1,23 +1,14 @@
 /* eslint-disable no-shadow */
 /* global l1Player localStorage document Blob navigator */
-/* global $ angular FileReader isElectron getAllProviders */
+/* global $ angular FileReader isElectron getAllProviders setPrototypeOfLocalStorage */
 /* eslint-disable global-require */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-param-reassign */
 /* eslint-disable import/no-unresolved */
+
 const main = () => {
-  const proto = Object.getPrototypeOf(localStorage);
-  proto.getObject = function getObject(key) {
-    const value = this.getItem(key);
-    return value && JSON.parse(value);
-  };
-  proto.setObject = function setObject(key, value) {
-    this.setItem(key, JSON.stringify(value));
-  };
-  Object.setPrototypeOf(localStorage, proto);
-
   const app = angular.module('listenone', ['ui-notification', 'loWebManager', 'cfp.hotkeys', 'lastfmClient', 'githubClient', 'pascalprecht.translate']);
-
+  setPrototypeOfLocalStorage();
   app.config([
     '$compileProvider',
     ($compileProvider) => {

--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-shadow */
 /* global l1Player localStorage document Blob navigator */
-/* global $ angular FileReader isElectron getAllProviders setPrototypeOfLocalStorage */
+/* global $ angular FileReader isElectron getAllProviders */
+/* global setPrototypeOfLocalStorage addPlayerLisnter */
 /* eslint-disable global-require */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-param-reassign */
@@ -1087,8 +1088,8 @@ const main = () => {
 
         return result;
       }
-
-      (chrome || browser).runtime.onMessage.addListener((msg, sender, sendResponse) => {
+      const mode = 'background';
+      addPlayerLisnter(mode, (msg, sender, sendResponse) => {
         if (typeof msg.type === 'string' && msg.type.split(':')[0] === 'BG_PLAYER') {
           switch (msg.type.split(':').slice(1).join('')) {
             case 'READY': {

--- a/js/bridge.js
+++ b/js/bridge.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-unused-vars */
+/*
+build a bridge between UI and audio player
+
+audio player has 2 modes, but share same protocol: front and background.
+
+* front: audio player and UI are in same environment
+* background: audio player is in background page.
+
+*/
+
+function getFrontPlayer() {
+  return undefined;
+}
+
+function getBackgroundPlayer() {
+  return chrome.extension.getBackgroundPage().player;
+}
+
+function getBackgroundPlayerAsync(callback) {
+  (chrome || browser).runtime.getBackgroundPage((w) => {
+    callback(w.player);
+  });
+}
+
+function getPlayer(mode) {
+  if (mode === 'front') {
+    return getFrontPlayer();
+  }
+  if (mode === 'background') {
+    return getBackgroundPlayer();
+  }
+  return undefined;
+}
+
+function getPlayerAsync(mode, callback) {
+  if (mode === 'front') {
+    const player = getFrontPlayer();
+    return callback(player);
+  }
+  if (mode === 'background') {
+    return getBackgroundPlayerAsync(callback);
+  }
+  return undefined;
+}

--- a/js/bridge.js
+++ b/js/bridge.js
@@ -43,3 +43,26 @@ function getPlayerAsync(mode, callback) {
   }
   return undefined;
 }
+
+function addFrontPlayerListener(listener) {
+
+}
+
+function addBackgroundPlayerListener(listener) {
+  return (chrome || browser).runtime.onMessage.addListener((msg, sender, res) => {
+    if (!msg.type.startsWith('BG_PLAYER:')) {
+      return null;
+    }
+    return listener(msg, sender, res);
+  });
+}
+
+function addPlayerLisnter(mode, listener) {
+  if (mode === 'front') {
+    return addFrontPlayerListener(listener);
+  }
+  if (mode === 'background') {
+    return addBackgroundPlayerListener(listener);
+  }
+  return null;
+}

--- a/js/bridge.js
+++ b/js/bridge.js
@@ -14,12 +14,12 @@ function getFrontPlayer() {
 }
 
 function getBackgroundPlayer() {
-  return chrome.extension.getBackgroundPage().player;
+  return chrome.extension.getBackgroundPage().threadPlayer;
 }
 
 function getBackgroundPlayerAsync(callback) {
   (chrome || browser).runtime.getBackgroundPage((w) => {
-    callback(w.player);
+    callback(w.threadPlayer);
   });
 }
 
@@ -57,7 +57,7 @@ function addBackgroundPlayerListener(listener) {
   });
 }
 
-function addPlayerLisnter(mode, listener) {
+function addPlayerListener(mode, listener) {
   if (mode === 'front') {
     return addFrontPlayerListener(listener);
   }
@@ -65,4 +65,21 @@ function addPlayerLisnter(mode, listener) {
     return addBackgroundPlayerListener(listener);
   }
   return null;
+}
+
+function frontPlayerSendMessage(message) {
+
+}
+
+function backgroundPlayerSendMessage(message) {
+  (chrome || browser).runtime.sendMessage(message);
+}
+
+function playerSendMessage(mode, message) {
+  if (mode === 'front') {
+    frontPlayerSendMessage(message);
+  }
+  if (mode === 'background') {
+    backgroundPlayerSendMessage(message);
+  }
 }

--- a/js/bridge.js
+++ b/js/bridge.js
@@ -10,7 +10,7 @@ audio player has 2 modes, but share same protocol: front and background.
 */
 
 function getFrontPlayer() {
-  return undefined;
+  return window.threadPlayer;
 }
 
 function getBackgroundPlayer() {
@@ -43,9 +43,9 @@ function getPlayerAsync(mode, callback) {
   }
   return undefined;
 }
-
+const frontPlayerListener = [];
 function addFrontPlayerListener(listener) {
-
+  frontPlayerListener.push(listener);
 }
 
 function addBackgroundPlayerListener(listener) {
@@ -68,7 +68,11 @@ function addPlayerListener(mode, listener) {
 }
 
 function frontPlayerSendMessage(message) {
-
+  if (frontPlayerListener !== []) {
+    frontPlayerListener.forEach((listener) => {
+      listener(message);
+    });
+  }
 }
 
 function backgroundPlayerSendMessage(message) {

--- a/js/l1_player.js
+++ b/js/l1_player.js
@@ -1,4 +1,4 @@
-/* global localStorage getPlayer getPlayerAsync addPlayerLisnter */
+/* global localStorage getPlayer getPlayerAsync addPlayerListener */
 // eslint-disable-next-line no-unused-vars
 {
   const proto = Object.getPrototypeOf(localStorage);
@@ -231,7 +231,7 @@
     }));
   };
 
-  addPlayerLisnter(mode, (msg, sender, res) => {
+  addPlayerListener(mode, (msg, sender, res) => {
     if (msg.type === 'BG_PLAYER:FRAME_UPDATE') {
       l1Player.status.playing = {
         ...l1Player.status.playing,

--- a/js/l1_player.js
+++ b/js/l1_player.js
@@ -30,7 +30,7 @@
     player.loadById(track_id);
   };
 
-  const mode = 'background';
+  const mode = 'front';
 
   const myPlayer = getPlayer(mode);
   const l1Player = {
@@ -266,7 +266,9 @@
         });
       }
     }
-    res();
+    if (res !== undefined) {
+      res();
+    }
   });
 
   window.l1Player = l1Player;

--- a/js/l1_player.js
+++ b/js/l1_player.js
@@ -1,4 +1,4 @@
-/* global localStorage */
+/* global localStorage getPlayer getPlayerAsync */
 // eslint-disable-next-line no-unused-vars
 {
   const proto = Object.getPrototypeOf(localStorage);
@@ -10,10 +10,6 @@
     this.setItem(key, JSON.stringify(value));
   };
   Object.setPrototypeOf(localStorage, proto);
-
-  const backgroundCall = (callback) => {
-    (chrome || browser).runtime.getBackgroundPage(callback);
-  };
 
   const initPlayer = (player) => {
     // add songs to playlist
@@ -34,119 +30,122 @@
     player.loadById(track_id);
   };
 
+  const mode = 'background';
+
+  const myPlayer = getPlayer(mode);
   const l1Player = {
     status: {
-      muted: chrome.extension.getBackgroundPage().player.muted,
-      volume: chrome.extension.getBackgroundPage().player.volume * 100,
-      loop_mode: chrome.extension.getBackgroundPage().player.loop_mode,
-      playing: chrome.extension.getBackgroundPage().player.playing,
+      muted: myPlayer.muted,
+      volume: myPlayer.volume * 100,
+      loop_mode: myPlayer.loop_mode,
+      playing: myPlayer.playing,
     },
     bootstrapTrack: null,
     play() {
-      backgroundCall((w) => {
-        w.player.play();
+      getPlayerAsync(mode, (player) => {
+        player.play();
       });
     },
     pause() {
-      backgroundCall((w) => {
-        w.player.pause();
+      getPlayerAsync(mode, (player) => {
+        player.pause();
       });
     },
     togglePlayPause() {
-      backgroundCall((w) => {
-        if (w.player.playing) {
-          w.player.pause();
+      getPlayerAsync(mode, (player) => {
+        if (player.playing) {
+          player.pause();
         } else {
-          w.player.play();
+          player.play();
         }
       });
     },
     playById(id) {
-      backgroundCall((w) => {
-        w.player.playById(id);
+      getPlayerAsync(mode, (player) => {
+        player.playById(id);
       });
     },
     loadById(idx) {
-      backgroundCall((w) => {
-        w.player.loadById(idx);
+      getPlayerAsync(mode, (player) => {
+        player.loadById(idx);
       });
     },
     seek(per) {
-      backgroundCall((w) => {
-        w.player.seek(per);
+      getPlayerAsync(mode, (player) => {
+        player.seek(per);
       });
     },
     next() {
-      backgroundCall((w) => {
-        w.player.skip('next');
+      getPlayerAsync(mode, (player) => {
+        player.skip('next');
       });
     },
     prev() {
-      backgroundCall((w) => {
-        w.player.skip('prev');
+      getPlayerAsync(mode, (player) => {
+        player.skip('prev');
       });
     },
     random() {
-      backgroundCall((w) => {
-        w.player.skip('random');
+      getPlayerAsync(mode, (player) => {
+        player.skip('random');
       });
     },
     setLoopMode(input) {
-      backgroundCall((w) => {
-        const { player } = w;
+      getPlayerAsync(mode, (player) => {
+        // eslint-disable-next-line no-param-reassign
         player.loop_mode = input;
       });
     },
     mute() {
-      backgroundCall((w) => {
-        w.player.mute();
+      getPlayerAsync(mode, (player) => {
+        player.mute();
       });
     },
     unmute() {
-      backgroundCall((w) => {
-        w.player.unmute();
+      getPlayerAsync(mode, (player) => {
+        player.unmute();
       });
     },
     toggleMute() {
-      backgroundCall((w) => {
-        if (w.player.muted) w.player.unmute();
-        else w.player.mute();
+      getPlayerAsync(mode, (player) => {
+        if (player.muted) player.unmute();
+        else player.mute();
       });
     },
     setVolume(per) {
-      backgroundCall((w) => {
-        const { player } = w;
+      getPlayerAsync(mode, (player) => {
+        // eslint-disable-next-line no-param-reassign
         player.volume = per / 100;
       });
     },
     adjustVolume(increase) {
-      backgroundCall((w) => {
-        w.player.adjustVolume(increase);
+      getPlayerAsync(mode, (player) => {
+        player.adjustVolume(increase);
       });
     },
     addTrack(track) {
-      backgroundCall((w) => {
-        w.player.insertAudio(track);
+      getPlayerAsync(mode, (player) => {
+        player.insertAudio(track);
       });
     },
     removeTrack(index) {
-      backgroundCall((w) => {
-        w.player.removeAudio(index);
+      getPlayerAsync(mode, (player) => {
+        player.removeAudio(index);
       });
     },
     addTracks(list) {
-      backgroundCall((w) => {
-        w.player.appendAudioList(list);
+      getPlayerAsync(mode, (player) => {
+        player.appendAudioList(list);
       });
     },
     clearPlaylist() {
-      backgroundCall((w) => {
-        w.player.clearPlaylist();
+      getPlayerAsync(mode, (player) => {
+        player.clearPlaylist();
       });
     },
     setNewPlaylist(list) {
-      backgroundCall((w) => {
-        w.player.setNewPlaylist(list);
+      getPlayerAsync(mode, (player) => {
+        player.setNewPlaylist(list);
       });
     },
     getTrackById(id) {
@@ -157,14 +156,14 @@
       l1Player.bootstrapTrack = fn;
     },
     connectPlayer() {
-      const player = this;
-      backgroundCall((w) => {
-        w.player.sendFullUpdate();
-        w.player.sendPlaylistEvent();
-        w.player.sendPlayingEvent();
-        w.player.sendLoadEvent();
-        if (!w.player.playing) {
-          initPlayer(player);
+      const thisPlayer = this;
+      getPlayerAsync(mode, (player) => {
+        player.sendFullUpdate();
+        player.sendPlaylistEvent();
+        player.sendPlayingEvent();
+        player.sendLoadEvent();
+        if (!player.playing) {
+          initPlayer(thisPlayer);
         }
       });
     },
@@ -254,15 +253,15 @@
             url = val;
           },
         }, msg.data, () => {
-          backgroundCall((w) => {
-            w.player.setMediaURI(url, msg.data.url || msg.data.id);
-            w.player.setAudioDisabled(false, msg.data.index);
-            w.player.finishLoad(msg.data.index, msg.data.playNow);
+          getPlayerAsync(mode, (player) => {
+            player.setMediaURI(url, msg.data.url || msg.data.id);
+            player.setAudioDisabled(false, msg.data.index);
+            player.finishLoad(msg.data.index, msg.data.playNow);
           });
         }, () => {
-          backgroundCall((w) => {
-            w.player.setAudioDisabled(true, msg.data.index);
-            w.player.skip('next');
+          getPlayerAsync(mode, (player) => {
+            player.setAudioDisabled(true, msg.data.index);
+            player.skip('next');
           });
         });
       }

--- a/js/l1_player.js
+++ b/js/l1_player.js
@@ -1,4 +1,4 @@
-/* global localStorage getPlayer getPlayerAsync */
+/* global localStorage getPlayer getPlayerAsync addPlayerLisnter */
 // eslint-disable-next-line no-unused-vars
 {
   const proto = Object.getPrototypeOf(localStorage);
@@ -231,7 +231,7 @@
     }));
   };
 
-  (chrome || browser).runtime.onMessage.addListener((msg, sender, res) => {
+  addPlayerLisnter(mode, (msg, sender, res) => {
     if (msg.type === 'BG_PLAYER:FRAME_UPDATE') {
       l1Player.status.playing = {
         ...l1Player.status.playing,

--- a/js/lowebutil.js
+++ b/js/lowebutil.js
@@ -1,6 +1,8 @@
 /* eslint-disable consistent-return */
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-unused-vars */
+/* global localStorage */
+
 function getParameterByName(name, url) { // eslint-disable-line no-unused-vars
   if (!url) url = window.location.href;
   name = name.replace(/[\[\]]/g, '\\$&'); // eslint-disable-line no-useless-escape
@@ -38,4 +40,16 @@ function cookieSet(cookie, callback) {
   remote.session.defaultSession.cookies.set(cookie).then((arg1, arg2) => {
     callback(null, arg1, arg2);
   });
+}
+
+function setPrototypeOfLocalStorage() {
+  const proto = Object.getPrototypeOf(localStorage);
+  proto.getObject = function getObject(key) {
+    const value = this.getItem(key);
+    return value && JSON.parse(value);
+  };
+  proto.setObject = function setObject(key, value) {
+    this.setItem(key, JSON.stringify(value));
+  };
+  Object.setPrototypeOf(localStorage, proto);
 }

--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -3,7 +3,7 @@
 /* global Howl Howler */
 
 {
-  const mode = 'background';
+  const mode = 'front';
 
   /**
    * Player class containing the state of our playlist and where we are in it.

--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -1,11 +1,9 @@
 /* eslint-disable no-underscore-dangle */
-/* global navigator MediaMetadata */
+/* global navigator MediaMetadata playerSendMessage */
 /* global Howl Howler */
 
 {
-  const sendEvent = (event) => {
-    (chrome || browser).runtime.sendMessage(event);
-  };
+  const mode = 'background';
 
   /**
    * Player class containing the state of our playlist and where we are in it.
@@ -121,7 +119,7 @@
     }
 
     retrieveMediaUrl(index, playNow) {
-      sendEvent({
+      playerSendMessage(mode, {
         type: 'BG_PLAYER:RETRIEVE_URL',
         data: {
           ...this.playlist[index],
@@ -216,7 +214,7 @@
           onvolume() {
           },
           onloaderror(id, err) {
-            sendEvent({
+            playerSendMessage(mode, {
               type: 'BG_PLAYER:PLAY_FAILED',
               data: err,
             });
@@ -226,7 +224,7 @@
             delete self._media_uri_list[data.id];
           },
           onplayerror(id, err) {
-            sendEvent({
+            playerSendMessage(mode, {
               type: 'BG_PLAYER:PLAY_FAILED',
               data: err,
             });
@@ -296,16 +294,16 @@
         one: 1,
         shuffle: 2,
       };
-      let mode = 0;
+      let myMode = 0;
       if (typeof input === 'string') {
-        mode = LOOP_MODE[input];
+        myMode = LOOP_MODE[input];
       } else {
-        mode = input;
+        myMode = input;
       }
-      if (!Object.values(LOOP_MODE).includes(mode)) {
+      if (!Object.values(LOOP_MODE).includes(myMode)) {
         return;
       }
-      this._loop_mode = mode;
+      this._loop_mode = myMode;
       this.sendFullUpdate();
     }
 
@@ -339,7 +337,7 @@
 
     mute() {
       Howler.mute(true);
-      sendEvent({
+      playerSendMessage(mode, {
         type: 'BG_PLAYER:MUTE',
         data: true,
       });
@@ -348,7 +346,7 @@
 
     unmute() {
       Howler.mute(false);
-      sendEvent({
+      playerSendMessage(mode, {
         type: 'BG_PLAYER:MUTE',
         data: false,
       });
@@ -409,7 +407,7 @@
       //     playing: this.playing,
       //   },
       // };
-      // sendEvent({
+      // playerSendMessage(mode, {
       //   type: 'BG_PLAYER:FULL_UPDATE',
       //   data,
       // });
@@ -428,14 +426,14 @@
         playbackRate: this.currentHowl ? this.currentHowl.rate() : 1,
         position: this.currentHowl ? this.currentHowl.seek() : 0,
       });
-      sendEvent({
+      playerSendMessage(mode, {
         type: 'BG_PLAYER:FRAME_UPDATE',
         data,
       });
     }
 
     async sendPlayingEvent(reason = 'UNKNOWN') {
-      sendEvent({
+      playerSendMessage(mode, {
         type: 'BG_PLAYER:PLAY_STATE',
         data: {
           isPlaying: this.playing,
@@ -445,7 +443,7 @@
     }
 
     async sendLoadEvent() {
-      sendEvent({
+      playerSendMessage(mode, {
         type: 'BG_PLAYER:LOAD',
         data: {
           ...this.currentAudio,
@@ -455,14 +453,14 @@
     }
 
     async sendVolumeEvent() {
-      sendEvent({
+      playerSendMessage(mode, {
         type: 'BG_PLAYER:VOLUME',
         data: this.volume * 100,
       });
     }
 
     async sendPlaylistEvent() {
-      sendEvent({
+      playerSendMessage(mode, {
         type: 'BG_PLAYER:PLAYLIST',
         data: this.playlist.map((audio) => ({ ...audio, howl: undefined })),
       });
@@ -471,13 +469,13 @@
 
   // Setup our new audio player class and pass it the playlist.
 
-  window.player = new Player();
-  window.player.setRefreshRate();
-  window.player.sendFullUpdate();
+  window.threadPlayer = new Player();
+  window.threadPlayer.setRefreshRate();
+  window.threadPlayer.sendFullUpdate();
   // TODO: enable after the play url retrieve logic moved to bg
   // navigator.mediaSession.setActionHandler('nexttrack', () => window.player.skip('next'));
   // navigator.mediaSession.setActionHandler('previoustrack', () => window.player.skip('prev'));
-  sendEvent({
+  playerSendMessage(mode, {
     type: 'BG_PLAYER:READY',
   });
 }

--- a/listen1.html
+++ b/listen1.html
@@ -23,6 +23,7 @@
     <script src="js/vendor/angular-translate-loader-static-files.min.js"></script>
     <script type="text/javascript" src="js/vendor/jquery-3.3.1.min.js"></script>
     <script type="text/javascript" src="js/vendor/angular-ui-notification.js"></script>
+    <script type="text/javascript" src="js/vendor/howler.core.min.js"></script>
     <script type="text/javascript" src="js/vendor/hotkeys.js"></script>
     <script type="text/javascript" src="js/vendor/md5.js"></script>
     <script type="text/javascript" src="js/vendor/aes.js"></script>
@@ -43,6 +44,9 @@
     <script type="text/javascript" src="js/provider/bilibili.js"></script>
     <script type="text/javascript" src="js/provider/migu.js"></script>
     <script type="text/javascript" src="js/provider/localmusic.js"></script>
+    
+    <script type="text/javascript" src="js/bridge.js"></script>
+    <script type="text/javascript" src="js/player_thread.js"></script>
     <script type="text/javascript" src="js/myplaylist.js"></script>
     <script type="text/javascript" src="js/loweb.js"></script>
     <script type="text/javascript" src="js/l1_player.js"></script>
@@ -477,7 +481,7 @@
                         <!-- now playing window-->
                         <div class="songdetail-wrapper" ng-class="{slidedown: window_type!=='track', coverbg: enableNowplayingCoverBackground}">
                             <div class="draggable-zone"></div>
-                            <div ng-if="enableNowplayingCoverBackground" class="bg" style="background-image: url({{ currentPlaying.img_url }});"></div>
+                            <div ng-if="enableNowplayingCoverBackground" class="bg" ng-style="{background-image: 'url(' + currentPlaying.img_url + ');'}"></div>
                             <div class="translate-switch" ng-click="toggleLyricTranslation()">译</div>
                             <div class="close" ng-class="isMac? 'mac':'' " ng-click="popWindow()"><svg class="icon"><use xlink:href="images/feather-sprite.svg#chevron-down"></use></svg></div>
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
             "js/github_api.js",
             "js/background.js",
             "js/vendor/howler.core.min.js",
+            "js/bridge.js",
             "js/player_thread.js"
         ],
         "persistent": true

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -11,6 +11,7 @@
             "js/github_api.js",
             "js/background.js",
             "js/vendor/howler.core.min.js",
+            "js/bridge.js",
             "js/player_thread.js"
         ],
         "persistent": true


### PR DESCRIPTION
Background player works good in browser environment, but when migrate to desktop electron, background thread is not allowed to play music. So we need to build "front" player. Besides, using front player in chrome extension is easier to debug.

## how does it work?

we create a bridge file to manage communication between UI and player (see js/bridge.js). It supports
* get player by mode (front or background)
* listen to player event by mode
* send event by player by mode

in background mode, we use chrome mechanism to send and receive message between UI (l1player/app) and Player(player_thread.js).

in front mode, we handle it by ourself. A global frontPlayerListener Array is used to store all listener functions and call them when event is triggered.

## furture work
* electron compatible
* front/background player mode switch by user
