### PR TITLE
fix current playing list not initialized bug

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -69,7 +69,6 @@ const main = () => {
           getAutoChooseSource,
         ),
       );
-      l1Player.connectPlayer();
     },
   ]);
 
@@ -1234,7 +1233,7 @@ const main = () => {
             case 'PLAYLIST': {
               // 'player:playlist'
               $scope.playlist = msg.data;
-              localStorage.setObject('playing-list', msg.data);
+              localStorage.setObject('current-playing', msg.data);
               break;
             }
 
@@ -1278,6 +1277,9 @@ const main = () => {
           sendResponse();
         }
       });
+
+      // connect player should run after all addListener function finished
+      l1Player.connectPlayer();
 
       // define keybind
       hotkeys.add({

--- a/js/l1_player.js
+++ b/js/l1_player.js
@@ -1,35 +1,6 @@
 /* global localStorage getPlayer getPlayerAsync addPlayerListener */
 // eslint-disable-next-line no-unused-vars
 {
-  const proto = Object.getPrototypeOf(localStorage);
-  proto.getObject = function getObject(key) {
-    const value = this.getItem(key);
-    return value && JSON.parse(value);
-  };
-  proto.setObject = function setObject(key, value) {
-    this.setItem(key, JSON.stringify(value));
-  };
-  Object.setPrototypeOf(localStorage, proto);
-
-  const initPlayer = (player) => {
-    // add songs to playlist
-    let localCurrentPlaying = localStorage.getObject('playing-list');
-    if (localCurrentPlaying === null) {
-      localCurrentPlaying = localStorage.getObject('current-playing');
-    }
-    if (localCurrentPlaying === null) {
-      return;
-    }
-    player.setNewPlaylist(localCurrentPlaying);
-
-    const localPlayerSettings = localStorage.getObject('player-settings');
-    if (localPlayerSettings === null) {
-      return;
-    }
-    const track_id = localPlayerSettings.nowplaying_track_id;
-    player.loadById(track_id);
-  };
-
   const mode = 'front';
 
   const myPlayer = getPlayer(mode);
@@ -156,15 +127,23 @@
       l1Player.bootstrapTrack = fn;
     },
     connectPlayer() {
-      const thisPlayer = this;
       getPlayerAsync(mode, (player) => {
+        if (!player.playing) {
+          // load local storage settings
+          const localCurrentPlaying = localStorage.getObject('current-playing');
+          if (localCurrentPlaying !== null) {
+            player.setNewPlaylist(localCurrentPlaying);
+          }
+
+          const localPlayerSettings = localStorage.getObject('player-settings');
+          if (localPlayerSettings !== null) {
+            player.loadById(localPlayerSettings.nowplaying_track_id);
+          }
+        }
         player.sendFullUpdate();
         player.sendPlaylistEvent();
         player.sendPlayingEvent();
         player.sendLoadEvent();
-        if (!player.playing) {
-          initPlayer(thisPlayer);
-        }
       });
     },
   };


### PR DESCRIPTION
what is this bug?
-----------------
* when open extension homepage, player bar is empty instead of showing listen1 logo.
 * after play playlist and close page, current playlist is not saved. Next time open extension, current playlist keep empty.

how to fix it?
-------------
UI and background/front player status sync is maintained by manual now instead of with help of framework. So sequence is important.

this bug happens because get status before init player status. So empty player status is always got and saved to local settings.

another bug reason is sync status before communication channel (bridge.js) finishes. So some message is missing. So we need to call sync function after addLisenter function finished.
