### PR TITLE
support close tab action setting

### DIFF
--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -113,5 +113,9 @@
  "kuwo": "kuwo",
  "migu": "migu",
  "qq": "qq",
- "xiami": "xiami"
+ "xiami": "xiami",
+ "_CLOSE_TAB_ACTION": "Close tab action",
+ "_VALID_AFTER_RESTART": "Valid after restart",
+ "_QUIT_SOFTWARE": "Quit",
+ "_MINIMIZE_TO_BACKGROUND": "Minimize to background"
 }

--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -116,6 +116,6 @@
  "xiami": "xiami",
  "_CLOSE_TAB_ACTION": "Close tab action",
  "_VALID_AFTER_RESTART": "Valid after restart",
- "_QUIT_SOFTWARE": "Quit",
+ "_QUIT_APPLICATION": "Quit Application",
  "_MINIMIZE_TO_BACKGROUND": "Minimize to background"
 }

--- a/i18n/fr_FR.json
+++ b/i18n/fr_FR.json
@@ -113,5 +113,9 @@
  "kuwo": "kuwo",
  "migu": "migu",
  "qq": "qq",
- "xiami": "xiami"
+ "xiami": "xiami",
+ "_CLOSE_TAB_ACTION": "Close tab action",
+ "_VALID_AFTER_RESTART": "Valid after restart",
+ "_QUIT_SOFTWARE": "Quit",
+ "_MINIMIZE_TO_BACKGROUND": "Minimize to background"
 }

--- a/i18n/fr_FR.json
+++ b/i18n/fr_FR.json
@@ -116,6 +116,6 @@
  "xiami": "xiami",
  "_CLOSE_TAB_ACTION": "Close tab action",
  "_VALID_AFTER_RESTART": "Valid after restart",
- "_QUIT_SOFTWARE": "Quit",
+ "_QUIT_APPLICATION": "Quit Application",
  "_MINIMIZE_TO_BACKGROUND": "Minimize to background"
 }

--- a/i18n/zh_CN.json
+++ b/i18n/zh_CN.json
@@ -113,5 +113,9 @@
  "kuwo": "酷我",
  "migu": "咪咕",
  "qq": "QQ",
- "xiami": "虾米"
+ "xiami": "虾米",
+ "_CLOSE_TAB_ACTION": "关闭标签页时行为",
+ "_VALID_AFTER_RESTART": "需重启生效",
+ "_QUIT_SOFTWARE": "退出应用",
+ "_MINIMIZE_TO_BACKGROUND": "最小化到后台"
 }

--- a/i18n/zh_CN.json
+++ b/i18n/zh_CN.json
@@ -116,6 +116,6 @@
  "xiami": "虾米",
  "_CLOSE_TAB_ACTION": "关闭标签页时行为",
  "_VALID_AFTER_RESTART": "需重启生效",
- "_QUIT_SOFTWARE": "退出应用",
+ "_QUIT_APPLICATION": "退出应用",
  "_MINIMIZE_TO_BACKGROUND": "最小化到后台"
 }

--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,7 @@
 /* global l1Player localStorage document Blob navigator */
 /* global $ angular FileReader isElectron getAllProviders */
 /* global setPrototypeOfLocalStorage addPlayerListener */
+/* global getLocalStorageValue getPlayer getPlayerAsync */
 /* eslint-disable global-require */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-param-reassign */
@@ -948,17 +949,10 @@ const main = () => {
         $scope.enableLyricFloatingWindow = localStorage.getObject('enable_lyric_floating_window');
         $scope.enableLyricTranslation = localStorage.getObject('enable_lyric_translation');
         $scope.enableLyricFloatingWindowTranslation = localStorage.getObject('enable_lyric_floating_window_translation');
-        $scope.enableAutoChooseSource = localStorage.getObject('enable_auto_choose_source');
-        $scope.enableNowplayingCoverBackground = localStorage.getObject('enable_nowplaying_cover_background');
+        $scope.enableAutoChooseSource = getLocalStorageValue('enable_auto_choose_source', true);
+        $scope.enableStopWhenClose = getLocalStorageValue('enable_stop_when_close', true);
+        $scope.enableNowplayingCoverBackground = getLocalStorageValue('enable_nowplaying_cover_background', false);
 
-        if ($scope.enableAutoChooseSource === null) {
-          // default on
-          $scope.enableAutoChooseSource = true;
-        }
-        if ($scope.enableNowplayingCoverBackground === null) {
-          // default false
-          $scope.enableNowplayingCoverBackground = false;
-        }
         $scope.applyGlobalShortcut();
         $scope.openLyricFloatingWindow();
       };
@@ -1087,7 +1081,16 @@ const main = () => {
 
         return result;
       }
-      const mode = 'front';
+      const mode = getLocalStorageValue('enable_stop_when_close', true) ? 'front' : 'background';
+
+      getPlayer(mode).setMode(mode);
+      if (mode === 'front') {
+        // avoid background keep playing when change to front mode
+        getPlayerAsync('background', (player) => {
+          player.pause();
+        });
+      }
+
       addPlayerListener(mode, (msg, sender, sendResponse) => {
         if (typeof msg.type === 'string' && msg.type.split(':')[0] === 'BG_PLAYER') {
           switch (msg.type.split(':').slice(1).join('')) {
@@ -1422,6 +1425,11 @@ const main = () => {
           $scope.enableAutoChooseSource = !$scope.enableAutoChooseSource;
         }
         localStorage.setObject('enable_auto_choose_source', $scope.enableAutoChooseSource);
+      };
+
+      $scope.setStopWhenClose = (status) => {
+        $scope.enableStopWhenClose = status;
+        localStorage.setObject('enable_stop_when_close', $scope.enableStopWhenClose);
       };
 
       $scope.setNowplayingCoverBackground = (toggle) => {

--- a/js/l1_player.js
+++ b/js/l1_player.js
@@ -1,7 +1,7 @@
-/* global localStorage getPlayer getPlayerAsync addPlayerListener */
+/* global localStorage getPlayer getPlayerAsync addPlayerListener getLocalStorageValue */
 // eslint-disable-next-line no-unused-vars
 {
-  const mode = 'front';
+  const mode = getLocalStorageValue('enable_stop_when_close', true) ? 'front' : 'background';
 
   const myPlayer = getPlayer(mode);
   const l1Player = {

--- a/js/lowebutil.js
+++ b/js/lowebutil.js
@@ -53,3 +53,12 @@ function setPrototypeOfLocalStorage() {
   };
   Object.setPrototypeOf(localStorage, proto);
 }
+
+function getLocalStorageValue(key, defaultValue) {
+  const keyString = localStorage.getItem(key);
+  let result = keyString && JSON.parse(keyString);
+  if (result === null) {
+    result = defaultValue;
+  }
+  return result;
+}

--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -3,8 +3,6 @@
 /* global Howl Howler */
 
 {
-  const mode = 'front';
-
   /**
    * Player class containing the state of our playlist and where we are in it.
    * Includes all methods for playing, skipping, updating the display, etc.
@@ -17,6 +15,11 @@
       this._loop_mode = 0;
       this._media_uri_list = {};
       this.playedFrom = 0;
+      this.mode = 'background';
+    }
+
+    setMode(newMode) {
+      this.mode = newMode;
     }
 
     setRefreshRate(rate = 10) {
@@ -121,7 +124,7 @@
     }
 
     retrieveMediaUrl(index, playNow) {
-      playerSendMessage(mode, {
+      playerSendMessage(this.mode, {
         type: 'BG_PLAYER:RETRIEVE_URL',
         data: {
           ...this.playlist[index],
@@ -147,7 +150,7 @@
       if (this.index !== index) Howler.stop();
       const data = this.playlist[index];
 
-      if (!data.howl || !this._media_uri_list[data.url]) {
+      if (!data.howl || !this._media_uri_list[data.id]) {
         this.retrieveMediaUrl(index, playNow);
       } else {
         this.finishLoad(index, playNow);
@@ -218,7 +221,7 @@
           onvolume() {
           },
           onloaderror(id, err) {
-            playerSendMessage(mode, {
+            playerSendMessage(this.mode, {
               type: 'BG_PLAYER:PLAY_FAILED',
               data: err,
             });
@@ -228,7 +231,7 @@
             delete self._media_uri_list[data.id];
           },
           onplayerror(id, err) {
-            playerSendMessage(mode, {
+            playerSendMessage(this.mode, {
               type: 'BG_PLAYER:PLAY_FAILED',
               data: err,
             });
@@ -341,7 +344,7 @@
 
     mute() {
       Howler.mute(true);
-      playerSendMessage(mode, {
+      playerSendMessage(this.mode, {
         type: 'BG_PLAYER:MUTE',
         data: true,
       });
@@ -350,7 +353,7 @@
 
     unmute() {
       Howler.mute(false);
-      playerSendMessage(mode, {
+      playerSendMessage(this.mode, {
         type: 'BG_PLAYER:MUTE',
         data: false,
       });
@@ -411,7 +414,7 @@
       //     playing: this.playing,
       //   },
       // };
-      // playerSendMessage(mode, {
+      // playerSendMessage(this.mode, {
       //   type: 'BG_PLAYER:FULL_UPDATE',
       //   data,
       // });
@@ -433,14 +436,14 @@
         });
       }
 
-      playerSendMessage(mode, {
+      playerSendMessage(this.mode, {
         type: 'BG_PLAYER:FRAME_UPDATE',
         data,
       });
     }
 
     async sendPlayingEvent(reason = 'UNKNOWN') {
-      playerSendMessage(mode, {
+      playerSendMessage(this.mode, {
         type: 'BG_PLAYER:PLAY_STATE',
         data: {
           isPlaying: this.playing,
@@ -450,7 +453,7 @@
     }
 
     async sendLoadEvent() {
-      playerSendMessage(mode, {
+      playerSendMessage(this.mode, {
         type: 'BG_PLAYER:LOAD',
         data: {
           ...this.currentAudio,
@@ -460,14 +463,14 @@
     }
 
     async sendVolumeEvent() {
-      playerSendMessage(mode, {
+      playerSendMessage(this.mode, {
         type: 'BG_PLAYER:VOLUME',
         data: this.volume * 100,
       });
     }
 
     async sendPlaylistEvent() {
-      playerSendMessage(mode, {
+      playerSendMessage(this.mode, {
         type: 'BG_PLAYER:PLAYLIST',
         data: this.playlist.map((audio) => ({ ...audio, howl: undefined })),
       });
@@ -484,7 +487,7 @@
   navigator.mediaSession.setActionHandler('pause', () => { window.threadPlayer.pause(); });
   // navigator.mediaSession.setActionHandler('nexttrack', () => window.player.skip('next'));
   // navigator.mediaSession.setActionHandler('previoustrack', () => window.player.skip('prev'));
-  playerSendMessage(mode, {
+  playerSendMessage(this.mode, {
     type: 'BG_PLAYER:READY',
   });
 }

--- a/listen1.html
+++ b/listen1.html
@@ -325,21 +325,18 @@
                           </div>
                           <div class="settings-title"><span>{{_CLOSE_TAB_ACTION}}({{_VALID_AFTER_RESTART}})</span></div>
                           <div class="settings-content">
-
-                            <div class="shortcut" class="btn btn-primary confirm-button" >
+                            <div class="shortcut">
                               <svg class="feather" ng-show="!enableStopWhenClose" ng-click="setStopWhenClose(true)"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
                               <svg class="feather" ng-show="enableStopWhenClose" ng-click="setStopWhenClose(false)"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
-                              <span style="margin-right: 20px;">{{_QUIT_SOFTWARE}}</span>
+                              <span style="margin-right: 20px;">{{_QUIT_APPLICATION}}</span>
                               <svg class="feather" ng-show="enableStopWhenClose" ng-click="setStopWhenClose(false)"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
                               <svg class="feather" ng-show="!enableStopWhenClose" ng-click="setStopWhenClose(true)"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
-                              <span style="margin-right: 20px;">{{_MINIMIZE_TO_BACKGROUND}}</span>
-                            
-                             
+                              <span> {{_MINIMIZE_TO_BACKGROUND}}</span>
                             </div>
                           </div>
                           <div class="settings-title"><span>{{_NOWPLAYING_COVER_BACKGROUND}}</span></div>
                           <div class="settings-content">
-                            <div class="shortcut" class="btn btn-primary confirm-button" >
+                            <div class="shortcut">
                               <svg class="feather" ng-show="!enableNowplayingCoverBackground" ng-click="setNowplayingCoverBackground(true)"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
                               <svg class="feather" ng-show="enableNowplayingCoverBackground" ng-click="setNowplayingCoverBackground(true)"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
                               {{_NOWPLAYING_COVER_BACKGROUND_NOTICE}}
@@ -347,17 +344,17 @@
                           </div>
                           <div class="settings-title"><span>{{_LYRIC_DISPLAY}}</span></div>
                           <div class="settings-content">
-                            <div class="shortcut" ng-if="!isChrome" class="btn btn-primary confirm-button" >
+                            <div class="shortcut" ng-if="!isChrome">
                               <svg class="feather" ng-show="!enableLyricFloatingWindow" ng-click="openLyricFloatingWindow(true)"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
                               <svg class="feather" ng-show="enableLyricFloatingWindow" ng-click="openLyricFloatingWindow(true)"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
                               <span ng-show="enableLyricFloatingWindow"></span>{{_SHOW_DESKTOP_LYRIC}}
                             </div>
-                            <div class="shortcut" class="btn btn-primary confirm-button" >
+                            <div class="shortcut">
                               <svg class="feather" ng-show="!enableLyricTranslation" ng-click="toggleLyricTranslation()"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
                               <svg class="feather" ng-show="enableLyricTranslation" ng-click="toggleLyricTranslation()"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
                               <span ng-show="enableLyricTranslation"></span>{{_SHOW_LYRIC_TRANSLATION}}
                             </div>
-                            <div class="shortcut" ng-if="!isChrome" class="btn btn-primary confirm-button" >
+                            <div class="shortcut" ng-if="!isChrome" >
                               <svg class="feather" ng-show="!enableLyricFloatingWindowTranslation" ng-click="toggleLyricFloatingWindowTranslation()"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
                               <svg class="feather" ng-show="enableLyricFloatingWindowTranslation" ng-click="toggleLyricFloatingWindowTranslation()"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
                               <span ng-show="enableLyricFloatingWindowTranslation"></span>{{_SHOW_DESKTOP_LYRIC_TRANSLATION}}

--- a/listen1.html
+++ b/listen1.html
@@ -323,12 +323,44 @@
                               {{_AUTO_CHOOSE_SOURCE_NOTICE}}
                             </div>
                           </div>
+                          <div class="settings-title"><span>{{_CLOSE_TAB_ACTION}}({{_VALID_AFTER_RESTART}})</span></div>
+                          <div class="settings-content">
+
+                            <div class="shortcut" class="btn btn-primary confirm-button" >
+                              <svg class="feather" ng-show="!enableStopWhenClose" ng-click="setStopWhenClose(true)"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
+                              <svg class="feather" ng-show="enableStopWhenClose" ng-click="setStopWhenClose(false)"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
+                              <span style="margin-right: 20px;">{{_QUIT_SOFTWARE}}</span>
+                              <svg class="feather" ng-show="enableStopWhenClose" ng-click="setStopWhenClose(false)"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
+                              <svg class="feather" ng-show="!enableStopWhenClose" ng-click="setStopWhenClose(true)"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
+                              <span style="margin-right: 20px;">{{_MINIMIZE_TO_BACKGROUND}}</span>
+                            
+                             
+                            </div>
+                          </div>
                           <div class="settings-title"><span>{{_NOWPLAYING_COVER_BACKGROUND}}</span></div>
                           <div class="settings-content">
                             <div class="shortcut" class="btn btn-primary confirm-button" >
                               <svg class="feather" ng-show="!enableNowplayingCoverBackground" ng-click="setNowplayingCoverBackground(true)"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
                               <svg class="feather" ng-show="enableNowplayingCoverBackground" ng-click="setNowplayingCoverBackground(true)"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
                               {{_NOWPLAYING_COVER_BACKGROUND_NOTICE}}
+                            </div>
+                          </div>
+                          <div class="settings-title"><span>{{_LYRIC_DISPLAY}}</span></div>
+                          <div class="settings-content">
+                            <div class="shortcut" ng-if="!isChrome" class="btn btn-primary confirm-button" >
+                              <svg class="feather" ng-show="!enableLyricFloatingWindow" ng-click="openLyricFloatingWindow(true)"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
+                              <svg class="feather" ng-show="enableLyricFloatingWindow" ng-click="openLyricFloatingWindow(true)"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
+                              <span ng-show="enableLyricFloatingWindow"></span>{{_SHOW_DESKTOP_LYRIC}}
+                            </div>
+                            <div class="shortcut" class="btn btn-primary confirm-button" >
+                              <svg class="feather" ng-show="!enableLyricTranslation" ng-click="toggleLyricTranslation()"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
+                              <svg class="feather" ng-show="enableLyricTranslation" ng-click="toggleLyricTranslation()"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
+                              <span ng-show="enableLyricTranslation"></span>{{_SHOW_LYRIC_TRANSLATION}}
+                            </div>
+                            <div class="shortcut" ng-if="!isChrome" class="btn btn-primary confirm-button" >
+                              <svg class="feather" ng-show="!enableLyricFloatingWindowTranslation" ng-click="toggleLyricFloatingWindowTranslation()"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
+                              <svg class="feather" ng-show="enableLyricFloatingWindowTranslation" ng-click="toggleLyricFloatingWindowTranslation()"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
+                              <span ng-show="enableLyricFloatingWindowTranslation"></span>{{_SHOW_DESKTOP_LYRIC_TRANSLATION}}
                             </div>
                           </div>
                           <div class="settings-title"><span>{{_BACKUP_PLAYLIST}}</span></div>
@@ -376,24 +408,7 @@
                               <button class="btn btn-primary confirm-button" ng-show="lastfm.isAuthRequested()" ng-click="lastfm.cancelAuth();">{{_CANCEL_CONNECT}}</button>
                             </div>
                           </div>
-                          <div class="settings-title"><span>{{_LYRIC_DISPLAY}}</span></div>
-                          <div class="settings-content">
-                            <div class="shortcut" ng-if="!isChrome" class="btn btn-primary confirm-button" >
-                              <svg class="feather" ng-show="!enableLyricFloatingWindow" ng-click="openLyricFloatingWindow(true)"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
-                              <svg class="feather" ng-show="enableLyricFloatingWindow" ng-click="openLyricFloatingWindow(true)"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
-                              <span ng-show="enableLyricFloatingWindow"></span>{{_SHOW_DESKTOP_LYRIC}}
-                            </div>
-                            <div class="shortcut" class="btn btn-primary confirm-button" >
-                              <svg class="feather" ng-show="!enableLyricTranslation" ng-click="toggleLyricTranslation()"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
-                              <svg class="feather" ng-show="enableLyricTranslation" ng-click="toggleLyricTranslation()"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
-                              <span ng-show="enableLyricTranslation"></span>{{_SHOW_LYRIC_TRANSLATION}}
-                            </div>
-                            <div class="shortcut" ng-if="!isChrome" class="btn btn-primary confirm-button" >
-                              <svg class="feather" ng-show="!enableLyricFloatingWindowTranslation" ng-click="toggleLyricFloatingWindowTranslation()"><use xlink:href="images/feather-sprite.svg#square"></use></svg>
-                              <svg class="feather" ng-show="enableLyricFloatingWindowTranslation" ng-click="toggleLyricFloatingWindowTranslation()"><use xlink:href="images/feather-sprite.svg#check-square"></use></svg>
-                              <span ng-show="enableLyricFloatingWindowTranslation"></span>{{_SHOW_DESKTOP_LYRIC_TRANSLATION}}
-                            </div>
-                          </div>
+
                           <div class="settings-title"><span>{{_ABOUT}}</span></div>
                           <div class="settings-content">
                             <p> Listen 1 {{_HOMEPAGE}}: <a open-url="'http://listen1.github.io/listen1/'"> http://listen1.github.io/listen1/ </a> </p>


### PR DESCRIPTION
support user choose action after click close tab. It is similar to click close button for desktop software. You can determine whether to close software or just minimize it to background.

Related technology
-------------------
There're 2 different modes for communication between UI and player. If user chooses close software after click, we use frontend mode, so player is running in same window with UI. If user chooses minimize to background, we use background player (thanks for @Dumeng work)

Limitation now
---------------
Changing from one mode from another can't take effect instantly. That's because front player and background player are two process and if we need to do that, we should pass one status to another and user can still notice music pause.

Another solution is using background player for all music playing, if we need to support change action without restart, we add lisnter for click close event and send background player pause command.

Future work
------------
compatible for desktop version. In desktop environment we use front mode to communicate.