### PR TITLE
fix: delete track in current playing problems

### DIFF
--- a/js/controller/play.js
+++ b/js/controller/play.js
@@ -580,8 +580,11 @@ angular.module('listenone').controller('PlayController', [
 
           case 'PLAYLIST': {
             // 'player:playlist'
-            $scope.playlist = msg.data;
-            localStorage.setObject('current-playing', msg.data);
+            $scope.$evalAsync(() => {
+              $scope.playlist = msg.data;
+              localStorage.setObject('current-playing', msg.data);
+            });
+
             break;
           }
 

--- a/js/l1_player.js
+++ b/js/l1_player.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 /* global getPlayer getPlayerAsync addPlayerListener getLocalStorageValue */
 {
   const mode = getLocalStorageValue('enable_stop_when_close', true)
@@ -132,6 +133,9 @@
               'current-playing'
             );
             if (localCurrentPlaying !== null) {
+              localCurrentPlaying.forEach((i) => {
+                i.disabled = false;
+              });
               player.setNewPlaylist(localCurrentPlaying);
             }
           }

--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -71,14 +71,21 @@
       }
 
       const { id: trackId } = this.currentAudio;
-      if (this.playlist[idx].howl && this.playlist[idx].howl.playing()) {
-        this.pause();
-      }
+
       this.playlist.splice(idx, 1);
       const newIndex = this.playlist.findIndex((i) => i.id === trackId);
       if (newIndex >= 0) {
         this.index = newIndex;
+      } else {
+        // current playing is deleted
+        if (idx >= this.playlist.length) {
+          this.index = this.playlist.length - 1;
+        } else {
+          this.index = idx;
+        }
+        this.play();
       }
+
       this.sendPlaylistEvent();
       this.sendLoadEvent();
     }
@@ -187,8 +194,8 @@
       if (!this.playlist[index]) {
         index = 0;
       }
-
-      if (this.index !== index) Howler.stop();
+      // stop when load new track to avoid multiple songs play in same time
+      Howler.stop();
       this.index = index;
 
       this.sendLoadEvent();

--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -69,6 +69,8 @@
       if (!this.playlist[idx]) {
         return;
       }
+      // restore playing status before change
+      const isPlaying = this.playing;
 
       const { id: trackId } = this.currentAudio;
 
@@ -83,7 +85,9 @@
         } else {
           this.index = idx;
         }
-        this.play();
+        if (isPlaying) {
+          this.play();
+        }
       }
 
       this.sendPlaylistEvent();

--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -69,10 +69,16 @@
       if (!this.playlist[idx]) {
         return;
       }
+
+      const { id: trackId } = this.currentAudio;
       if (this.playlist[idx].howl && this.playlist[idx].howl.playing()) {
-        this.skip('next');
+        this.pause();
       }
       this.playlist.splice(idx, 1);
+      const newIndex = this.playlist.findIndex((i) => i.id === trackId);
+      if (newIndex >= 0) {
+        this.index = newIndex;
+      }
       this.sendPlaylistEvent();
       this.sendLoadEvent();
     }


### PR DESCRIPTION
The problem is related to two reasons.

1. after delete songs, playlist does not rerender instantly, you need move mouse to see song removed.
The reason is about data sync in angularjs. In common case, we define varible in $scope and modify it in normal funciton. $scope.varible value changed and UI is updated. But if we update this value in a callback function (maybe we add listener to some event, network response for example), the render will not be triggered. So In repo, evalAsync (or timeout, apply, this anuglar functions are same) is called to force angular rerender. But why async function modification is not updated is still a question for me. If you know, please reply to me, thanks.

One solution for fixing network request is use $http or use $q.when to wrap axios, so angularjs will wrap all request with ability to detect change. In Listen1, we use $q.when to wrap axios lib.

Another solution maybe using redux to manage global state and make request to update these state.

2. delete song break playlist functions
now we use index to indicate songs to remove. After remove, current playing index is not updated so when doing next action, old index value is still used.

We update index for every action which affects this.index and sync.