### PR TITLE
fix: pending music load for 15 secs

### DIFF
--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -149,14 +149,14 @@
 
     clearPlaylist() {
       this.playlist = [];
-      Howler.stop();
+      Howler.unload();
       this.sendPlaylistEvent();
       this.sendLoadEvent();
     }
 
     setNewPlaylist(list) {
       if (list.length) {
-        Howler.stop();
+        Howler.unload();
 
         this.playlist = list.map((audio) => ({
           ...audio,
@@ -244,7 +244,7 @@
       }
       // stop when load new track to avoid multiple songs play in same time
       if (index !== this.index) {
-        Howler.stop();
+        Howler.unload();
       }
       this.index = index;
 
@@ -356,7 +356,7 @@
      * @param  {String} direction 'next' or 'prev'.
      */
     skip(direction) {
-      Howler.stop();
+      Howler.unload();
       // Get the next track based on the direction of the track.
       let nextIndexFn = null;
       if (this._loop_mode === 2 || direction === 'random') {


### PR DESCRIPTION
## What is the bug?
If change song too quickly, or keep click next track, song loading time will be 15 seconds for all music files. User will see play button does not change to pause status and song is not playing.

If user open devtools, a song request is showing pending for 15 seconds. 

## Reason
Browser always has limit to concurrent http request to 6 (according to specification, protect DDOS from client). So we accidently hit the limit. But indeed we only load one music file one time, so some resource is not released properly.

Digging into howler source file, there's only one API to create, Howler(). If I change html5 to false, everything goes fine, but I need to wait for the whole music file download finish and start to play music which is bad for UX. If I change html5 option on, pending happens again.

After searching for source code in howler, I find out that if html5 is enabled, howler will try to create some audio element and put them in a "pool". If we play music, it will fetch one audio element from pool. So I add some log about available pool object and find problem always happend when pool is empty. 

So here's the problem. When I call `Howler.stop()`, indeed audio element resource is not release. `Howler.unload()` should be called so sound stop playing and audio element is released and back to pool.

## Solution
Change Howler.stop -> Hower.unload
