### PR TITLE
fix: font

### DIFF
--- a/src/assets/css/common.css
+++ b/src/assets/css/common.css
@@ -4,7 +4,8 @@ body {
   padding: 0;
   font-size: var(--text-default-size);
   color: var(--text-default-color);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', 'PingFang SC,' STHeiti, system-ui, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', 'Hiragino Sans GB', system-ui,
+    sans-serif;
 }
 
 a {


### PR DESCRIPTION
accidentally have a , in `'PingFang SC,'` also removes STHeiti