### PR TITLE
fix: font render error

### DIFF
--- a/src/assets/css/common.css
+++ b/src/assets/css/common.css
@@ -4,8 +4,7 @@ body {
   padding: 0;
   font-size: var(--text-default-size);
   color: var(--text-default-color);
-  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', 'Hiragino Sans GB', system-ui,
-    sans-serif;
+  font-family: -apple-system, 'Helvetica Neue', Helvetica, 'Segoe UI', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', system-ui, sans-serif;
 }
 
 a {


### PR DESCRIPTION
It seems that BlinkMacSystemFont is problematic on Windows, it will have a make yahei higher priority than Segoe UI. I've also move yahei to lower priority due to its lack of font weight.