### PR TITLE
fix: more reliable playing status

### DIFF
--- a/src/composition/player.ts
+++ b/src/composition/player.ts
@@ -68,9 +68,9 @@ function formatTime(secs: number) {
 }
 export class PlayerEventListener {
   async onEvent(name: string, params: any) {
-    if (name === 'playing') {
+    if (name === 'custom:playlist_playing') {
       player.isPlaying = true;
-    } else if (name === 'pause') {
+    } else if (name === 'custom:playlist_pause') {
       player.isPlaying = false;
     } else if (name === 'custom:nowplaying') {
       const { track } = params;

--- a/src/services/l1_player.ts
+++ b/src/services/l1_player.ts
@@ -52,12 +52,37 @@ function posMod(m: number, n: number) {
   return ((m % n) + n) % n;
 }
 
+/*
+l1PlayerProto
+Wrap html audio element to provide playlist management.
+
+Usage:
+```
+const l1Player = l1PlayerProto();
+class PlayerEventListener {
+  async onEvent(name: string, params: any) {
+    if(name === 'playing'){
+      // support all audio element event
+    } else if (name === 'timeupdate') {
+      // support all audio element event
+    } else if (name === 'custom:playlist'){
+      // use custom prefix to indicate custom event
+    }
+  }
+}
+const listener = {}
+l1Player.addEventListener([new PlayerEventListener()]);
+l1Player.playTracks([track]);
+```
+*/
 class l1PlayerProto {
   playlist = <Track[]>[];
   muted = false;
   volume = 1; // 0-1
   loopMode = PlayerLoopMode.LOOP_ALL;
   playing: Track | null = null;
+  // NOTICE: isPlaying indicate whether playing task is started
+  // NOT indicate whether audio file is playing
   isPlaying = false;
   _audio: HTMLAudioElement;
   _eventListenerArray = <PlayerListener[]>[];

--- a/src/services/l1_player.ts
+++ b/src/services/l1_player.ts
@@ -167,6 +167,7 @@ class l1PlayerProto {
     }
     if (tryCount > this.playlist.length) {
       this._emit('custom:playlist_not_playable', {});
+      this.pause();
       return;
     }
     if (!this.isPlaying) {


### PR DESCRIPTION
Now playing status in music control has some problem.

1. when one song finishes and skip to next song, playing status would first become pause and then become playing

2. when auto switch music source, in searching period, playing status is pause, and we can't interrupt that.

The reason is former design use audio playing status as our playing status. Indeed user click play button to let player know: now playlist is playing instead of playing one song. So in brief:

User click play button to START TASK of playing, instead of playing one song.

So for more reliable control, we add new state in l1_player.js to indicate whether play task is going.