### PR TITLE
feat: use light/dark theme in accordance with the browser

### DIFF
--- a/js/controller/profile.js
+++ b/js/controller/profile.js
@@ -123,7 +123,11 @@ angular.module('listenone').controller('ProfileController', [
     };
     $scope.setLang(defaultLang);
 
-    let defaultTheme = 'white';
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        let defaultTheme = 'black'; // dark mode
+    } else {
+        let defaultTheme = 'white'; 
+    }
     if (localStorage.getObject('theme') !== null) {
       defaultTheme = localStorage.getObject('theme');
     }


### PR DESCRIPTION
Set default theme according to the browser theme.
(Maybe add a checkbox for en/disabling this too.)