### PR TITLE
fix: win control missing on nowplaying

### DIFF
--- a/electron_src/package.json
+++ b/electron_src/package.json
@@ -91,7 +91,7 @@
     }
   },
   "devDependencies": {
-    "electron": "14.2.3",
+    "electron": "14.2.4",
     "electron-builder": "^22.14.5",
     "electron-reloader": "^1.2.1"
   },

--- a/electron_src/yarn.lock
+++ b/electron_src/yarn.lock
@@ -870,10 +870,10 @@ electron-store@^8.0.1:
     conf "^10.0.3"
     type-fest "^1.0.2"
 
-electron@14.2.3:
-  version "14.2.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-14.2.3.tgz#3facf572c57cefe8ce80154ad3e63f937784644b"
-  integrity sha512-7wBqvzUKhK1tw544w3+F8J7NajnqURGC4pH3VFTiBHU5ayiI/oaTTXJxyFLZ54zsR7xwon/3dYEVjIm2i68+Zg==
+electron@14.2.4:
+  version "14.2.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-14.2.4.tgz#243c71a16a85a4f70086d003b3437cd30b541da0"
+  integrity sha512-uskCIp+fpohqVYtM2Q28rbXLqGjZ6sWYylXcX6N+K8jR8kR2eHuDMIkO8DzWrTsqA6t4UNAzn+bJnA3VfIIjQw==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"

--- a/src/views/NowPlaying.vue
+++ b/src/views/NowPlaying.vue
@@ -25,7 +25,7 @@
       <div class="close app-region-nodrag cursor-pointer absolute left-8 right-8 w-8 h-8" :class="isMac ? 'mac top-16' : 'top-8 '" @click="toggleNowPlaying()">
         <vue-feather type="chevron-down"></vue-feather>
       </div>
-
+      <WindowControl class="absolute right-2 top-4" />
       <!-- <div v-if="!isChrome && !isMac" class="window-control">
                 <svg class="icon" window-control="window_min">
                   <use href="#minimize-2" />
@@ -150,6 +150,7 @@ import useSettings from '../composition/settings';
 import { datetimeFormats } from '../i18n/index';
 import MediaService from '../services/MediaService';
 import type { Comment } from '../provider/types';
+import WindowControl from '../components/WindowControl.vue';
 const { t, d } = useI18n({
   //@ts-ignore mismatch arg num
   datetimeFormats

--- a/src/views/NowPlaying.vue
+++ b/src/views/NowPlaying.vue
@@ -144,13 +144,13 @@
 import { watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
+import WindowControl from '../components/WindowControl.vue';
 import useOverlay from '../composition/overlay';
 import usePlayer from '../composition/player';
 import useSettings from '../composition/settings';
 import { datetimeFormats } from '../i18n/index';
-import MediaService from '../services/MediaService';
 import type { Comment } from '../provider/types';
-import WindowControl from '../components/WindowControl.vue';
+import MediaService from '../services/MediaService';
 const { t, d } = useI18n({
   //@ts-ignore mismatch arg num
   datetimeFormats


### PR DESCRIPTION
🆙 deps(electron) to resolve a bug that media breaks on old machines