### PR TITLE
Storage refactor

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@ import blackTransparentStyle from './assets/css/themes/origin_transparent.css?in
 import { PlayerEventListener } from './composition/player';
 import useRedHeart from './composition/redheart';
 import useSettings from './composition/settings';
+import SettingModel from './models/SettingModel';
 import iDB from './services/DBService';
 import type { Track } from './services/l1_player';
 import { l1Player } from './services/l1_player';
@@ -53,7 +54,7 @@ const initPlayer = async () => {
     //@ts-ignore not null
     tracks = currentPlaylist.order.map((id) => localCurrentPlaying.find((track) => track.id == id));
   }
-  const dbSettings = await iDB.Settings.where('key').equals('playerSettings').toArray();
+  const dbSettings = await SettingModel.getArrayByKey('playerSettings');
 
   tracks.forEach((i) => {
     i.disabled = false;

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,17 +14,12 @@ import blackStyle from './assets/css/themes/origin.css?inline';
 import blackTransparentStyle from './assets/css/themes/origin_transparent.css?inline';
 import { PlayerEventListener } from './composition/player';
 import useRedHeart from './composition/redheart';
-import useSettings, { migrateSettings } from './composition/settings';
-import iDB, { dbMigrate } from './services/DBService';
+import useSettings from './composition/settings';
+import iDB from './services/DBService';
 import type { Track } from './services/l1_player';
 import { l1Player } from './services/l1_player';
 import { initMediaSession, MediaSessionEventListener } from './services/media_session';
 import Home from './views/Home.vue';
-
-if (!localStorage.getItem('V3_MIGRATED')) {
-  migrateSettings();
-  dbMigrate();
-}
 
 const { settings, loadSettings } = useSettings();
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,7 @@
+import { initDBService } from './services/DBService';
 import GithubClient from './services/GithubService';
+
+initDBService();
 
 chrome.browserAction.onClicked.addListener(() => {
   const url = chrome.extension.getURL('index.html');

--- a/src/composition/settings.ts
+++ b/src/composition/settings.ts
@@ -1,6 +1,7 @@
 import { reactive, watch } from 'vue';
 import type { Language } from '../i18n';
 import iDB from '../services/DBService';
+
 import { setPrototypeOfLocalStorage } from '../utils';
 setPrototypeOfLocalStorage();
 
@@ -20,8 +21,10 @@ const nameMapping = {
   playerSettings: 'player_settings',
   theme: 'theme'
 };
+
 type nameMapping = typeof nameMapping;
 type mappingKey = keyof nameMapping;
+
 const settings = reactive({
   language: 'zh-CN' as Language,
   enableAutoChooseSource: false,
@@ -42,12 +45,14 @@ const settings = reactive({
   lyricFontWeight: 400,
   autoChooseSourceList: ['kuwo', 'qq', 'migu']
 });
+
 type settingsType = typeof settings;
 type settingsKey = keyof settingsType;
 type Entries<T> = {
   [K in keyof T]: [K, T[K]];
 }[keyof T][];
 type settingEntries = Entries<settingsType>;
+
 async function flushSettings() {
   await iDB.Settings.bulkPut(
     (Object.keys(settings) as settingsKey[]).map((key) => ({

--- a/src/composition/settings.ts
+++ b/src/composition/settings.ts
@@ -1,7 +1,6 @@
 import { reactive, watch } from 'vue';
 import type { Language } from '../i18n';
 import SettingModel from '../models/SettingModel';
-import iDB from '../services/DBService';
 
 import { setPrototypeOfLocalStorage } from '../utils';
 setPrototypeOfLocalStorage();
@@ -69,10 +68,7 @@ function saveSettingsToDB(newValue: Partial<Record<settingsKey, unknown>>) {
 }
 
 async function loadSettings() {
-  const dbRes: Record<string, unknown> = (await iDB.Settings.toArray()).reduce((ret: Record<string, unknown>, cur) => {
-    ret[cur.key] = cur.value;
-    return ret;
-  }, {});
+  const dbRes: Record<string, unknown> = await SettingModel.loadSettings();
   if (Object.values(dbRes).some((value) => value === undefined)) {
     flushSettings();
   } else {
@@ -91,11 +87,7 @@ export function migrateSettings() {
   setSettings(lsSettings);
 }
 async function getSettingsAsync() {
-  const dbRes: Record<string, unknown> = (await iDB.Settings.toArray()).reduce((ret: Record<string, unknown>, cur) => {
-    ret[cur.key] = cur.value;
-    return ret;
-  }, {});
-  return dbRes;
+  return await SettingModel.loadSettings();
 }
 export function getSetting(key: settingsKey) {
   return settings[key];

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,22 @@ import './assets/css/index.css';
 import i18n from './i18n';
 import router from './router';
 import { setPrototypeOfLocalStorage } from './utils';
+import { initDBService } from './services/DBService';
+import { migrateSettings } from './composition/settings';
+import { dbMigrate } from './services/DBService';
 
-setPrototypeOfLocalStorage();
+function prepareApp() {
+  setPrototypeOfLocalStorage();
+
+  // init db service
+  initDBService();
+  if (!localStorage.getItem('V3_MIGRATED')) {
+    migrateSettings();
+    dbMigrate();
+  }
+}
+
+prepareApp();
 
 const app = createApp(App);
 app

--- a/src/models/PlaylistModel.ts
+++ b/src/models/PlaylistModel.ts
@@ -1,0 +1,34 @@
+export const defaultPlaylists: { [key: string]: any } = {
+  current: {
+    id: 'current',
+    title: 'current',
+    cover_img_url: 'images/mycover.jpg',
+    type: 'current',
+    order: []
+  },
+  lmplaylist_reserve: {
+    id: 'lmplaylist_reserve',
+    title: '本地音乐',
+    cover_img_url: 'images/mycover.jpg',
+    type: 'local',
+    order: []
+  },
+  myplaylist_redheart: {
+    id: 'myplaylist_redheart',
+    title: '我喜欢的音乐',
+    cover_img_url: 'images/mycover.jpg',
+    type: 'my',
+    order: []
+  }
+};
+
+export default class PlaylistModel {
+  id!: string;
+  title!: string;
+  cover_img_url!: string;
+  source_url?: string;
+  type!: 'current' | 'favorite' | 'my' | 'local';
+  order!: string[];
+
+  static readonly INDEX_STRING = '&id, type';
+}

--- a/src/models/SettingModel.ts
+++ b/src/models/SettingModel.ts
@@ -64,4 +64,10 @@ export default class SettingModel {
     }, {});
     return dbRes;
   }
+  static getByKey(key: string) {
+    return iDB.Settings.get({ key });
+  }
+  static async updateByKey(key: string, updateFn: any) {
+    await iDB.Settings.where('key').equals(key).modify(updateFn);
+  }
 }

--- a/src/models/SettingModel.ts
+++ b/src/models/SettingModel.ts
@@ -57,4 +57,11 @@ export default class SettingModel {
       iDB.Settings.put({ key, value });
     }
   }
+  static async loadSettings() {
+    const dbRes: Record<string, unknown> = (await iDB.Settings.toArray()).reduce((ret: Record<string, unknown>, cur) => {
+      ret[cur.key] = cur.value;
+      return ret;
+    }, {});
+    return dbRes;
+  }
 }

--- a/src/models/SettingModel.ts
+++ b/src/models/SettingModel.ts
@@ -1,6 +1,37 @@
+import iDB from '../services/DBService';
+
 export default class SettingModel {
   key!: string;
   value!: unknown;
 
   static readonly INDEX_STRING = '&key';
+  static prepare() {
+    iDB.Settings.bulkAdd([
+      {
+        key: 'favorite_playlist_order',
+        value: []
+      },
+      {
+        key: 'my_playlist_order',
+        value: ['myplaylist_redheart']
+      }
+    ]);
+
+    // migrate my playlist without redheart entry
+    iDB.Settings.get({ key: 'my_playlist_order' }).then((order: any) => {
+      if (!order) {
+        iDB.Settings.put({
+          key: 'my_playlist_order',
+          value: ['myplaylist_redheart']
+        });
+      } else {
+        if (order.value.findIndex((id: string) => id == 'myplaylist_redheart') == -1) {
+          iDB.Settings.put({
+            key: 'my_playlist_order',
+            value: ['myplaylist_redheart', ...order.value]
+          });
+        }
+      }
+    });
+  }
 }

--- a/src/models/SettingModel.ts
+++ b/src/models/SettingModel.ts
@@ -70,4 +70,10 @@ export default class SettingModel {
   static async updateByKey(key: string, updateFn: any) {
     await iDB.Settings.where('key').equals(key).modify(updateFn);
   }
+  static setByKey(key: string, value: any) {
+    iDB.Settings.put({
+      key,
+      value
+    });
+  }
 }

--- a/src/models/SettingModel.ts
+++ b/src/models/SettingModel.ts
@@ -1,5 +1,5 @@
 import iDB from '../services/DBService';
-
+import { settingsKey, settingsType, settingEntries } from '../composition/settings';
 export default class SettingModel {
   key!: string;
   value!: unknown;
@@ -34,7 +34,27 @@ export default class SettingModel {
       }
     });
   }
+
   static async getArrayByKey(key: string) {
     return iDB.Settings.where('key').equals(key).toArray();
+  }
+
+  static async flushSettings(settings: settingsType) {
+    await iDB.Settings.bulkPut(
+      (Object.keys(settings) as settingsKey[]).map((key) => ({
+        key,
+        value: settings[key]
+      }))
+    );
+  }
+  static setSettings(newValue: Partial<Record<settingsKey, unknown>>) {
+    for (const [key, value] of Object.entries(newValue) as settingEntries) {
+      iDB.Settings.put({ key, value });
+    }
+  }
+  static saveSettingsToDB(newValue: Partial<Record<settingsKey, unknown>>) {
+    for (const [key, value] of Object.entries(newValue) as settingEntries) {
+      iDB.Settings.put({ key, value });
+    }
   }
 }

--- a/src/models/SettingModel.ts
+++ b/src/models/SettingModel.ts
@@ -1,0 +1,6 @@
+export default class SettingModel {
+  key!: string;
+  value!: unknown;
+
+  static readonly INDEX_STRING = '&key';
+}

--- a/src/models/SettingModel.ts
+++ b/src/models/SettingModel.ts
@@ -34,4 +34,7 @@ export default class SettingModel {
       }
     });
   }
+  static async getArrayByKey(key: string) {
+    return iDB.Settings.where('key').equals(key).toArray();
+  }
 }

--- a/src/models/TrackModel.ts
+++ b/src/models/TrackModel.ts
@@ -1,0 +1,18 @@
+export default class TrackModel {
+  id!: string;
+  playlist!: string;
+  title?: string;
+  artist?: string;
+  artist_id?: string;
+  album?: string;
+  album_id?: string;
+  img_url?: string;
+  source?: string;
+  // source_url: String,
+  // lyric_url: String,
+  disabled?: string;
+
+  static readonly INDEX_STRING = '&[playlist+id], playlist, id, title, artist, artist_id, album, album_id, source, disabled';
+
+  [key: string]: unknown;
+}

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -60,33 +60,7 @@ export function initDBService() {
     });
   }
 
-  iDB.Settings.bulkAdd([
-    {
-      key: 'favorite_playlist_order',
-      value: []
-    },
-    {
-      key: 'my_playlist_order',
-      value: ['myplaylist_redheart']
-    }
-  ]);
-
-  // migrate my playlist without redheart entry
-  iDB.Settings.get({ key: 'my_playlist_order' }).then((order: any) => {
-    if (!order) {
-      iDB.Settings.put({
-        key: 'my_playlist_order',
-        value: ['myplaylist_redheart']
-      });
-    } else {
-      if (order.value.findIndex((id: string) => id == 'myplaylist_redheart') == -1) {
-        iDB.Settings.put({
-          key: 'my_playlist_order',
-          value: ['myplaylist_redheart', ...order.value]
-        });
-      }
-    }
-  });
+  SettingkModel.prepare();
 }
 
 function migratePlaylist(tracks: any, newId: string, newTitle: string, newType: 'current' | 'favorite' | 'my' | 'local') {

--- a/src/services/DBService.ts
+++ b/src/services/DBService.ts
@@ -1,57 +1,22 @@
 import Dexie from 'dexie';
-
+import TrackModel from '../models/TrackModel';
+import SettingkModel from '../models/SettingModel';
+import PlaylistModel, { defaultPlaylists } from '../models/PlaylistModel';
 interface MODEL {
   new (): unknown;
   INDEX_STRING: string;
 }
 
-class Track {
-  id!: string;
-  playlist!: string;
-  title?: string;
-  artist?: string;
-  artist_id?: string;
-  album?: string;
-  album_id?: string;
-  img_url?: string;
-  source?: string;
-  // source_url: String,
-  // lyric_url: String,
-  disabled?: string;
-
-  static readonly INDEX_STRING = '&[playlist+id], playlist, id, title, artist, artist_id, album, album_id, source, disabled';
-
-  [key: string]: unknown;
-}
-
-class Setting {
-  key!: string;
-  value!: unknown;
-
-  static readonly INDEX_STRING = '&key';
-}
-
-export class Playlist {
-  id!: string;
-  title!: string;
-  cover_img_url!: string;
-  source_url?: string;
-  type!: 'current' | 'favorite' | 'my' | 'local';
-  order!: string[];
-
-  static readonly INDEX_STRING = '&id, type';
-}
-
 const models: { [key: string]: MODEL } = {
-  Tracks: Track,
-  Settings: Setting,
-  Playlists: Playlist
+  Tracks: TrackModel,
+  Settings: SettingkModel,
+  Playlists: PlaylistModel
 };
 
 export class L1DB extends Dexie {
-  Tracks!: Dexie.Table<Track, [string, string]>;
-  Settings!: Dexie.Table<Setting, [string]>;
-  Playlists!: Dexie.Table<Playlist, [string]>;
+  Tracks!: Dexie.Table<TrackModel, [string, string]>;
+  Settings!: Dexie.Table<SettingkModel, [string]>;
+  Playlists!: Dexie.Table<PlaylistModel, [string]>;
 
   constructor() {
     super('Listen1');
@@ -60,7 +25,7 @@ export class L1DB extends Dexie {
       return ret;
     }, {});
     this.version(1).stores(schema);
-    this.Tracks.mapToClass(Track);
+    this.Tracks.mapToClass(TrackModel);
   }
 }
 
@@ -82,30 +47,6 @@ iDB.tables.forEach((table) => {
   table.hook('creating', createHook);
   table.hook('updating', updateHook);
 });
-
-const defaultPlaylists: { [key: string]: any } = {
-  current: {
-    id: 'current',
-    title: 'current',
-    cover_img_url: 'images/mycover.jpg',
-    type: 'current',
-    order: []
-  },
-  lmplaylist_reserve: {
-    id: 'lmplaylist_reserve',
-    title: '本地音乐',
-    cover_img_url: 'images/mycover.jpg',
-    type: 'local',
-    order: []
-  },
-  myplaylist_redheart: {
-    id: 'myplaylist_redheart',
-    title: '我喜欢的音乐',
-    cover_img_url: 'images/mycover.jpg',
-    type: 'my',
-    order: []
-  }
-};
 
 for (const key in defaultPlaylists) {
   const value = defaultPlaylists[key];

--- a/src/services/GithubService.ts
+++ b/src/services/GithubService.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { isElectron } from '../utils';
-import iDB from './DBService';
+
+import SettingModel from '../models/SettingModel';
 
 const OAUTH_URL = 'https://github.com/login/oauth';
 const API_URL = 'https://api.github.com';
@@ -13,9 +14,7 @@ const GithubAPI = axios.create({
   headers: { accept: 'application/json' }
 });
 GithubAPI.interceptors.request.use(async (config) => {
-  const dbRes = await iDB.Settings.get({
-    key: 'GITHUB_ACCESS_TOKEN'
-  });
+  const dbRes = await SettingModel.getByKey('GITHUB_ACCESS_TOKEN');
   const accessToken = dbRes?.value;
   if (config.headers) config.headers.Authorization = `token ${accessToken}`;
   return config;
@@ -39,11 +38,9 @@ const GithubClient = {
         headers: { accept: 'application/json' }
       });
       const ak = res.data.access_token;
-      if (ak)
-        iDB.Settings.put({
-          key: 'GITHUB_ACCESS_TOKEN',
-          value: ak
-        });
+      if (ak) {
+        SettingModel.setByKey('GITHUB_ACCESS_TOKEN', ak);
+      }
       return ak;
     },
     _openAuthUrl: () => {
@@ -86,9 +83,7 @@ const GithubClient = {
       }
     },
     updateStatus: async () => {
-      const dbRes = await iDB.Settings.get({
-        key: 'GITHUB_ACCESS_TOKEN'
-      });
+      const dbRes = await SettingModel.getByKey('GITHUB_ACCESS_TOKEN');
       const accessToken = dbRes?.value;
       if (!accessToken) {
         Github.status = 0;
@@ -104,10 +99,7 @@ const GithubClient = {
       return Github.status;
     },
     logout: () => {
-      iDB.Settings.put({
-        key: 'GITHUB_ACCESS_TOKEN',
-        value: null
-      });
+      SettingModel.setByKey('GITHUB_ACCESS_TOKEN', null);
       Github.status = 0;
     }
   },


### PR DESCRIPTION
# What does this PR about
indexed db now is only choice for storage layer, which may cause some problems:

* get key value pair using indexed has worse performance than get using localstorage
* one requirement for desktop users is green lite version (which means you can copy-parse directory to use software anywhere), so indexed db storage will replaced with file or sqilte api.

so i'm trying to move all call to indexed db to `models` directory, by call model member functions. It will seperate business logic from stoarge layer and we can have better control about peresistancy problems.

# Progress

- [ ] settings

- [ ] playerlist

- [ ] tracks