### PR TITLE
feat: Manifest v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 node_modules
 dist
+_metadata/

--- a/js/background.js
+++ b/js/background.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-unused-vars */
 /* global GithubClient */
-chrome.browserAction.onClicked.addListener((tab) => {
+chrome.action.onClicked.addListener((tab) => {
   chrome.tabs.create(
     {
-      url: chrome.extension.getURL('listen1.html'),
+      url: chrome.runtime.getURL('listen1.html'),
     },
     (new_tab) => {
       // Tab opened.
@@ -11,182 +11,182 @@ chrome.browserAction.onClicked.addListener((tab) => {
   );
 });
 
-function hack_referer_header(details) {
-  const replace_referer = true;
-  let replace_origin = true;
-  let add_referer = true;
-  let add_origin = true;
+// function hack_referer_header(details) {
+//   const replace_referer = true;
+//   let replace_origin = true;
+//   let add_referer = true;
+//   let add_origin = true;
 
-  let referer_value = '';
-  let origin_value = '';
-  let ua_value = '';
+//   let referer_value = '';
+//   let origin_value = '';
+//   let ua_value = '';
 
-  if (details.url.includes('://music.163.com/')) {
-    referer_value = 'https://music.163.com/';
-  }
-  if (details.url.includes('://interface3.music.163.com/')) {
-    referer_value = 'https://music.163.com/';
-  }
-  if (details.url.includes('://gist.githubusercontent.com/')) {
-    referer_value = 'https://gist.githubusercontent.com/';
-  }
+//   if (details.url.includes('://music.163.com/')) {
+//     referer_value = 'https://music.163.com/';
+//   }
+//   if (details.url.includes('://interface3.music.163.com/')) {
+//     referer_value = 'https://music.163.com/';
+//   }
+//   if (details.url.includes('://gist.githubusercontent.com/')) {
+//     referer_value = 'https://gist.githubusercontent.com/';
+//   }
 
-  if (details.url.includes('.xiami.com/')) {
-    add_origin = false;
-    add_referer = false;
-    // referer_value = "https://www.xiami.com";
-  }
+//   if (details.url.includes('.xiami.com/')) {
+//     add_origin = false;
+//     add_referer = false;
+//     // referer_value = "https://www.xiami.com";
+//   }
 
-  if (details.url.includes('c.y.qq.com/')) {
-    referer_value = 'https://y.qq.com/';
-    origin_value = 'https://y.qq.com';
-  }
-  if (
-    details.url.includes('i.y.qq.com/') ||
-    details.url.includes('qqmusic.qq.com/') ||
-    details.url.includes('music.qq.com/') ||
-    details.url.includes('imgcache.qq.com/')
-  ) {
-    referer_value = 'https://y.qq.com/';
-  }
+//   if (details.url.includes('c.y.qq.com/')) {
+//     referer_value = 'https://y.qq.com/';
+//     origin_value = 'https://y.qq.com';
+//   }
+//   if (
+//     details.url.includes('i.y.qq.com/') ||
+//     details.url.includes('qqmusic.qq.com/') ||
+//     details.url.includes('music.qq.com/') ||
+//     details.url.includes('imgcache.qq.com/')
+//   ) {
+//     referer_value = 'https://y.qq.com/';
+//   }
 
-  if (details.url.includes('.kugou.com/')) {
-    referer_value = 'https://www.kugou.com/';
-  }
+//   if (details.url.includes('.kugou.com/')) {
+//     referer_value = 'https://www.kugou.com/';
+//   }
 
-  if (details.url.includes('.kuwo.cn/')) {
-    referer_value = 'https://www.kuwo.cn/';
-  }
+//   if (details.url.includes('.kuwo.cn/')) {
+//     referer_value = 'https://www.kuwo.cn/';
+//   }
 
-  if (
-    details.url.includes('.bilibili.com/') ||
-    details.url.includes('.bilivideo.com/')
-  ) {
-    referer_value = 'https://www.bilibili.com/';
-    replace_origin = false;
-    add_origin = false;
-  }
+//   if (
+//     details.url.includes('.bilibili.com/') ||
+//     details.url.includes('.bilivideo.com/')
+//   ) {
+//     referer_value = 'https://www.bilibili.com/';
+//     replace_origin = false;
+//     add_origin = false;
+//   }
 
-  if (details.url.includes('.migu.cn')) {
-    referer_value = 'https://music.migu.cn/v3/music/player/audio?from=migu';
-  }
+//   if (details.url.includes('.migu.cn')) {
+//     referer_value = 'https://music.migu.cn/v3/music/player/audio?from=migu';
+//   }
 
-  if (details.url.includes('m.music.migu.cn')) {
-    referer_value = 'https://m.music.migu.cn/';
-  }
+//   if (details.url.includes('m.music.migu.cn')) {
+//     referer_value = 'https://m.music.migu.cn/';
+//   }
 
-  if (
-    details.url.includes('app.c.nf.migu.cn') ||
-    details.url.includes('d.musicapp.migu.cn')
-  ) {
-    ua_value =
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30';
-    add_origin = false;
-    add_referer = false;
-  }
+//   if (
+//     details.url.includes('app.c.nf.migu.cn') ||
+//     details.url.includes('d.musicapp.migu.cn')
+//   ) {
+//     ua_value =
+//       'Mozilla/5.0 (iPhone; CPU iPhone OS 14_3 like Mac OS X) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30';
+//     add_origin = false;
+//     add_referer = false;
+//   }
 
-  if (details.url.includes('jadeite.migu.cn')) {
-    ua_value = 'okhttp/3.12.12';
-    add_origin = false;
-    add_referer = false;
-  }
+//   if (details.url.includes('jadeite.migu.cn')) {
+//     ua_value = 'okhttp/3.12.12';
+//     add_origin = false;
+//     add_referer = false;
+//   }
 
-  if (origin_value === '') {
-    origin_value = referer_value;
-  }
+//   if (origin_value === '') {
+//     origin_value = referer_value;
+//   }
 
-  let isRefererSet = false;
-  let isOriginSet = false;
-  let isUASet = false;
-  const headers = details.requestHeaders;
-  const blockingResponse = {};
+//   let isRefererSet = false;
+//   let isOriginSet = false;
+//   let isUASet = false;
+//   const headers = details.requestHeaders;
+//   const blockingResponse = {};
 
-  for (let i = 0, l = headers.length; i < l; i += 1) {
-    if (
-      replace_referer &&
-      headers[i].name === 'Referer' &&
-      referer_value !== ''
-    ) {
-      headers[i].value = referer_value;
-      isRefererSet = true;
-    }
-    if (replace_origin && headers[i].name === 'Origin' && origin_value !== '') {
-      headers[i].value = origin_value;
-      isOriginSet = true;
-    }
-    if (headers[i].name === 'User-Agent' && ua_value !== '') {
-      headers[i].value = ua_value;
-      isUASet = true;
-    }
-  }
+//   for (let i = 0, l = headers.length; i < l; i += 1) {
+//     if (
+//       replace_referer &&
+//       headers[i].name === 'Referer' &&
+//       referer_value !== ''
+//     ) {
+//       headers[i].value = referer_value;
+//       isRefererSet = true;
+//     }
+//     if (replace_origin && headers[i].name === 'Origin' && origin_value !== '') {
+//       headers[i].value = origin_value;
+//       isOriginSet = true;
+//     }
+//     if (headers[i].name === 'User-Agent' && ua_value !== '') {
+//       headers[i].value = ua_value;
+//       isUASet = true;
+//     }
+//   }
 
-  if (add_referer && !isRefererSet && referer_value !== '') {
-    headers.push({
-      name: 'Referer',
-      value: referer_value,
-    });
-  }
+//   if (add_referer && !isRefererSet && referer_value !== '') {
+//     headers.push({
+//       name: 'Referer',
+//       value: referer_value,
+//     });
+//   }
 
-  if (add_origin && !isOriginSet && origin_value !== '') {
-    headers.push({
-      name: 'Origin',
-      value: origin_value,
-    });
-  }
+//   if (add_origin && !isOriginSet && origin_value !== '') {
+//     headers.push({
+//       name: 'Origin',
+//       value: origin_value,
+//     });
+//   }
 
-  if (!isUASet && ua_value !== '') {
-    headers.push({
-      name: 'User-Agent',
-      value: ua_value,
-    });
-  }
+//   if (!isUASet && ua_value !== '') {
+//     headers.push({
+//       name: 'User-Agent',
+//       value: ua_value,
+//     });
+//   }
 
-  blockingResponse.requestHeaders = headers;
-  return blockingResponse;
-}
+//   blockingResponse.requestHeaders = headers;
+//   return blockingResponse;
+// }
 
-const urls = [
-  '*://*.music.163.com/*',
-  '*://music.163.com/*',
-  '*://*.xiami.com/*',
-  '*://i.y.qq.com/*',
-  '*://c.y.qq.com/*',
-  '*://*.kugou.com/*',
-  '*://*.kuwo.cn/*',
-  '*://*.bilibili.com/*',
-  '*://*.bilivideo.com/*',
-  '*://*.migu.cn/*',
-  '*://*.githubusercontent.com/*',
-];
+// const urls = [
+//   '*://*.music.163.com/*',
+//   '*://music.163.com/*',
+//   '*://*.xiami.com/*',
+//   '*://i.y.qq.com/*',
+//   '*://c.y.qq.com/*',
+//   '*://*.kugou.com/*',
+//   '*://*.kuwo.cn/*',
+//   '*://*.bilibili.com/*',
+//   '*://*.bilivideo.com/*',
+//   '*://*.migu.cn/*',
+//   '*://*.githubusercontent.com/*',
+// ];
 
-try {
-  chrome.webRequest.onBeforeSendHeaders.addListener(
-    hack_referer_header,
-    {
-      urls,
-    },
-    ['requestHeaders', 'blocking', 'extraHeaders']
-  );
-} catch (err) {
-  // before chrome v72, extraHeader is not supported
-  chrome.webRequest.onBeforeSendHeaders.addListener(
-    hack_referer_header,
-    {
-      urls,
-    },
-    ['requestHeaders', 'blocking']
-  );
-}
+// try {
+//   chrome.webRequest.onBeforeSendHeaders.addListener(
+//     hack_referer_header,
+//     {
+//       urls,
+//     },
+//     ['requestHeaders', 'blocking', 'extraHeaders']
+//   );
+// } catch (err) {
+//   // before chrome v72, extraHeader is not supported
+//   chrome.webRequest.onBeforeSendHeaders.addListener(
+//     hack_referer_header,
+//     {
+//       urls,
+//     },
+//     ['requestHeaders', 'blocking']
+//   );
+// }
 
-/**
- * Get tokens.
- */
+// /**
+//  * Get tokens.
+//  */
 
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.type !== 'code') {
-    return;
-  }
+// chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+//   if (request.type !== 'code') {
+//     return;
+//   }
 
-  GithubClient.github.handleCallback(request.code);
-  sendResponse();
-});
+//   GithubClient.github.handleCallback(request.code);
+//   sendResponse();
+// });

--- a/manifest.json
+++ b/manifest.json
@@ -1,35 +1,8 @@
 {
   "background": {
-    "scripts": [
-      "js/vendor/axios.min.js",
-      "js/vendor/forge_listen1_fork.min.js",
-
-      "js/github.js",
-      "js/background.js",
-      "js/vendor/howler.core.min.js",
-      "js/bridge.js",
-
-      "js/vendor/async.min.js",
-      "js/vendor/lru-cache.min.js",
-      "js/lowebutil.js",
-
-      "js/provider/xiami.js",
-      "js/provider/qq.js",
-      "js/provider/netease.js",
-      "js/provider/kugou.js",
-      "js/provider/kuwo.js",
-      "js/provider/bilibili.js",
-      "js/provider/migu.js",
-      "js/provider/taihe.js",
-      "js/provider/localmusic.js",
-      "js/myplaylist.js",
-
-      "js/loweb.js",
-      "js/player_thread.js"
-    ],
-    "persistent": true
+    "service_worker": "js/background.js"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "images/logo.png",
     "default_title": "Listen 1"
   },
@@ -39,12 +12,10 @@
     "16": "images/logo_16.png",
     "48": "images/logo_48.png"
   },
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Listen 1",
-  "permissions": [
-    "notifications",
-    "unlimitedStorage",
-    "cookies",
+  "permissions": ["notifications", "unlimitedStorage", "cookies"],
+  "host_permissions": [
     "*://music.163.com/*",
     "*://*.music.163.com/*",
     "*://*.xiami.com/*",
@@ -56,12 +27,12 @@
     "*://*.migu.cn/*",
     "*://api.github.com/*",
     "*://github.com/*",
-    "*://gist.githubusercontent.com/*",
-    "webRequest",
-    "webRequestBlocking"
+    "*://gist.githubusercontent.com/*"
   ],
   "version": "2.22.0",
-  "web_accessible_resources": ["images/*"],
+  "web_accessible_resources": [
+    { "resources": ["images/*"], "matches": ["<all_urls>"] }
+  ],
   "content_scripts": [
     {
       "matches": ["https://listen1.github.io/listen1/*"],

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,21 @@
   },
   "manifest_version": 3,
   "name": "Listen 1",
-  "permissions": ["notifications", "unlimitedStorage", "cookies"],
+  "permissions": [
+    "notifications",
+    "unlimitedStorage",
+    "cookies",
+    "declarativeNetRequest",
+    "*://music.163.com/*",
+    "*://*.music.163.com/*",
+    "*://*.xiami.com/*",
+    "*://*.qq.com/*",
+    "*://*.kugou.com/",
+    "*://*.kuwo.cn/",
+    "*://*.bilibili.com/*",
+    "*://*.bilivideo.com/*",
+    "*://*.migu.cn/*"
+  ],
   "host_permissions": [
     "*://music.163.com/*",
     "*://*.music.163.com/*",
@@ -29,6 +43,15 @@
     "*://github.com/*",
     "*://gist.githubusercontent.com/*"
   ],
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "ruleset_1",
+        "enabled": true,
+        "path": "rules.json"
+      }
+    ]
+  },
   "version": "2.22.0",
   "web_accessible_resources": [
     { "resources": ["images/*"], "matches": ["<all_urls>"] }

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        {
+          "header": "Referer",
+          "operation": "set",
+          "value": "https://y.qq.com/"
+        },
+        { "header": "Origin", "operation": "set", "value": "https://y.qq.com" }
+      ]
+    },
+    "condition": {
+      "urlFilter": "c.y.qq.com",
+      "resourceTypes": ["xmlhttprequest"]
+    }
+  }
+]


### PR DESCRIPTION
Now chrome web store only accept v3 version release, so in order to publish in chrome web store, manifest v3 migration is needed.

Major Changes:
* rename field names in manifest file 
  *  background mode not available (need extra work)
  * github connect not available (need extra work)
* migrate webRequest API to declarativeNetRequest API. 

Progress now: almost done, left work is analyze hack_referer code in background.js and use new declearative api to do same  job.
