### PR TITLE
fix: break bilibili website

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node-forge": "^1.2.1",
     "notyf": "^3.10.0",
     "postcss": "^8.4.12",
-    "prettier": "^2.6.0",
+    "prettier": "^2.6.1",
     "rollup-plugin-chrome-extension": "3.6.6",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-zip": "^1.0.3",

--- a/src/rules.json
+++ b/src/rules.json
@@ -105,11 +105,6 @@
           "header": "Referer",
           "operation": "set",
           "value": "https://www.bilibili.com/"
-        },
-        {
-          "header": "Origin",
-          "operation": "set",
-          "value": "https://www.bilibili.com/"
         }
       ]
     },

--- a/src/rules.json
+++ b/src/rules.json
@@ -108,7 +108,8 @@
         },
         {
           "header": "Origin",
-          "operation": "remove"
+          "operation": "set",
+          "value": "https://www.bilibili.com/"
         }
       ]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,10 +2421,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
-  integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
+prettier@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.1.tgz#d472797e0d7461605c1609808e27b80c0f9cfe17"
+  integrity sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
It seems that v3 now breaks normal access to bilibili due to remove origin.
We might need to find a way to limit scope of request redirects.