### PR TITLE
fix clearPlaylist issue

### DIFF
--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -147,8 +147,8 @@
     }
 
     clearPlaylist() {
+      this.stopAll(); // stop the loadded track before remove list
       this.playlist = [];
-      this.stopAll();
       Howler.unload();
       this.sendPlaylistEvent();
       this.sendLoadEvent();


### PR DESCRIPTION
BUG复现：
1. 播放歌曲 A （加载歌曲）
2. 播放歌曲 B
3. 返回播放歌曲 A，并在播放列表中点击“清空”，歌曲A仍然在播放

修复：
在清空`playList`前 执行 `stopAll()`