### PR TITLE
feat: add random playlist

### DIFF
--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -10,6 +10,7 @@
   class Player {
     constructor() {
       this.playlist = [];
+      this._random_playlist = [];
       this.index = -1;
       this._loop_mode = 0;
       this._media_uri_list = {};
@@ -377,14 +378,44 @@
     skip(direction) {
       Howler.unload();
       // Get the next track based on the direction of the track.
-      let nextIndexFn = null;
-      if (this._loop_mode === 2 || direction === 'random') {
-        // TODO: shuffle algorithm instead of random
-        nextIndexFn = () => Math.floor(Math.random() * this.playlist.length);
-      } else if (direction === 'prev') {
-        nextIndexFn = (idx) => (idx - 1) % this.playlist.length;
-      } else if (direction === 'next') {
-        nextIndexFn = (idx) => (idx + 1) % this.playlist.length;
+      let nextIndexFn = (idx) => {
+        let l = this.playlist.length;
+        let rdx = idx;
+        let random_mode = false;
+
+        if (this._loop_mode === 2 || direction === 'random') {
+          if(this._random_playlist.length/2 !== l) {
+            // construction random playlist
+            let a = Array.from({length:l},(_v,i)=>i);
+            for (let i = 0; i < l; i++) {
+              let e = l-i-1;
+              let s = Math.floor(Math.random() * e);
+              let t = a[s];
+              a[s] = a[e];
+              a[e] = t;
+              // lookup table
+              a[t+l] = e;
+            }
+            this._random_playlist = a;
+          }
+          // is random mode
+          random_mode = true;
+          rdx = this._random_playlist[idx + l];
+        }
+        else {
+          // clear random playlist
+          this._random_playlist = [];
+        }
+
+        if (direction === 'prev') {
+          if (rdx === 0) rdx = l;
+          rdx -= 1;
+        }
+        else {
+          if (rdx === l-1) rdx = -1;
+          rdx += 1;
+        }
+        return random_mode ? this._random_playlist[rdx % l] : rdx;
       }
       this.index = nextIndexFn(this.index);
 
@@ -579,7 +610,7 @@
   const threadPlayer = new Player();
   threadPlayer.setRefreshRate();
   window.threadPlayer = threadPlayer;
-  
+
   if ('mediaSession' in navigator) {
     const { mediaSession } = navigator;
     mediaSession.setActionHandler('play', () => {


### PR DESCRIPTION
1. 添加了随机播放列表
2. 修复了上一首及下一首产生的数组越界bug

[listen1_desktop #655](https://github.com/listen1/listen1_desktop/issues/665)

随机播放列表重置条件
1. 歌单长度发生改变
2. 非随机模式模式并切换歌曲后重建

**使用随机播放列表方式是由于随机播放时会有回到上一首的需求**

现在在发生上下越界时，会回到开头或末尾