### PR TITLE
feat: add random playlist

### DIFF
--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -410,10 +410,9 @@
           if (rdx === 0) rdx = l;
           rdx -= 1;
         } else {
-          if (rdx === l - 1) rdx = -1;
           rdx += 1;
         }
-        return random_mode ? this._random_playlist[rdx % l] : rdx;
+        return random_mode ? this._random_playlist[rdx % l] : rdx % l;
       };
       this.index = nextIndexFn(this.index);
 

--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -380,10 +380,11 @@
       // Get the next track based on the direction of the track.
       const nextIndexFn = (idx) => {
         const l = this.playlist.length;
-        let rdx = idx;
-        let random_mode = false;
+        const random_mode = this._loop_mode === 2 || direction === 'random';
 
-        if (this._loop_mode === 2 || direction === 'random') {
+        let rdx = idx;
+
+        if (random_mode) {
           if (this._random_playlist.length / 2 !== l) {
             // construction random playlist
             const a = Array.from({ length: l }, (_v, i) => i);
@@ -398,8 +399,6 @@
             }
             this._random_playlist = a;
           }
-          // is random mode
-          random_mode = true;
           rdx = this._random_playlist[idx + l];
         } else if (this._random_playlist.length !== 0) {
           // clear random playlist

--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -384,25 +384,24 @@
         let random_mode = false;
 
         if (this._loop_mode === 2 || direction === 'random') {
-          if(this._random_playlist.length/2 !== l) {
+          if (this._random_playlist.length / 2 !== l) {
             // construction random playlist
-            const a = Array.from({length:l},(_v,i)=>i);
+            const a = Array.from({ length: l }, (_v, i) => i);
             for (let i = 0; i < l; i += 1) {
-              const e = l-i-1;
+              const e = l - i - 1;
               const s = Math.floor(Math.random() * e);
               const t = a[s];
               a[s] = a[e];
               a[e] = t;
               // lookup table
-              a[t+l] = e;
+              a[t + l] = e;
             }
             this._random_playlist = a;
           }
           // is random mode
           random_mode = true;
           rdx = this._random_playlist[idx + l];
-        }
-        else if (this._random_playlist.length !== 0) {
+        } else if (this._random_playlist.length !== 0) {
           // clear random playlist
           this._random_playlist = [];
         }
@@ -410,13 +409,12 @@
         if (direction === 'prev') {
           if (rdx === 0) rdx = l;
           rdx -= 1;
-        }
-        else {
-          if (rdx === l-1) rdx = -1;
+        } else {
+          if (rdx === l - 1) rdx = -1;
           rdx += 1;
         }
         return random_mode ? this._random_playlist[rdx % l] : rdx;
-      }
+      };
       this.index = nextIndexFn(this.index);
 
       let tryCount = 0;


### PR DESCRIPTION
1. 添加了随机播放列表
2. 修复了上一首产生的数组越界bug

[listen1_desktop #655](https://github.com/listen1/listen1_desktop/issues/665)
#664 #576 #523 

随机播放列表重置条件
1. 歌单长度发生改变
2. 非随机模式模式并切换歌曲后重建

**使用随机播放列表方式是由于随机播放时会有回到“上一首”的需求**

现在在发生下越界时，会回到末尾

PS.
顺序排列是一种特殊的随机结果，在曲目数<=(3~5)时，有较高的机率出现这种情况，未具体计算概率。