### PR TITLE
feat: optimize modern theme performance issue

### DIFF
--- a/listen1.html
+++ b/listen1.html
@@ -4008,20 +4008,15 @@
                     </div> -->
                   
                     <ul id="cover-list" class="cover-list">
-                      <li
-                        ng-class="{
-                          lipause:!isPlaying,
-                          liplay:isPlaying,
-                          rotatecircl:song.id===currentPlaying.id,
-                          b:song.id === currentPlaying.id,
-                          c:$index === nextPlayIndex,
-                          a:$index === prePlayIndex,
-                          def:$index === defPlayIndex[0]||$index === defPlayIndex[1]}"
-                        class="hid"
-                        id="song{{ song.id }}"
-                        ng-repeat="song in playlist track by $index"
-                        draggable="true"
-                      >
+                      <li ng-class="{
+                        lipause:!isPlaying,
+                        liplay:isPlaying,
+                        rotatecircl:song.id === currentPlaying.id,
+                        a:song.id === getSongIdByIndex(currentIndex-1),
+                        b:song.id === currentPlaying.id,
+                        c:song.id === getSongIdByIndex(currentIndex+1),
+                        def:song.id === getSongIdByIndex(currentIndex+2)||song.id === getSongIdByIndex(currentIndex-2)}" class="hid"
+                            id="song{{ song.id }}" ng-repeat="song in staged_playlist track by song.id" draggable="true">
                     <img
                     err-src="https://y.gtimg.cn/mediastyle/global/img/album_300.png"
                     ng-src="{{song.img_url.replace('/120/','/300/')}}?param=300y300" alt="">


### PR DESCRIPTION
## 优化现代主题的性能问题

### 现象
切换到新主题后，CPU，GPU用量马上上升，切换回非现代主题后问题消失

### 可能原因
cover-list 元素会渲染所有当前歌单的元素。因为元素会涉及较多的渲染更新（因为其属性值需要和当前播放状态同步），可能是造成计算消耗的主要原因

### 优化方法
cover-list的用途是显示最近的歌曲封面，包括上一首，下一首，当前。为了动画过渡，还需要上一首的上一首和下一首的下一首。所以，我们采用了`staged_playlist`来维护这5首歌的列表，避免了对整个歌单进行遍历。
为了新的修改，原来使用index方式来判断是否未上一首的遍历prePlayIndex也被prevSongId代替，用来记录上一首歌曲的id。

### 进一步调研
通过在windows系统上的测试，性能问题还是存在。通过一系列的对比测试发现，主要原因在于动画的部分。
新主题使用了旋转，变形等动画效果，这些效果需要借助cpu或者gpu的计算。但之前windows系统上禁用了gpu加速，导致了如果计算渲染此类元素时，会让cpu能耗非常高。

针对这种情况，我们修改了windows系统上的设定，默认允许gpu加速功能。这样，虽然加重了gpu的负担，但是好歹能让cpu的占用率控制在合理范围内。其他可用的优化还需要进一步调查。

### 优化后表现
在桌面版测试，能看到cpu基本能和原来的持平。更多测试正在进行中。