### PR TITLE
fix: crash when playlist less than 5 songs in modern theme

### DIFF
--- a/js/controller/play.js
+++ b/js/controller/play.js
@@ -31,10 +31,14 @@ function useModernTheme() {
 
 function getSafeIndex(index, length) {
   if (index < 0) {
-    return length + index;
+    const r = index % length;
+    if (r < 0) {
+      return length + (index % length);
+    }
+    return r;
   }
   if (index > length - 1) {
-    return index - length;
+    return index % length;
   }
   return index;
 }
@@ -72,17 +76,22 @@ angular.module('listenone').controller('PlayController', [
 
     $scope.currentIndex = 0;
     $scope.staged_playlist = [];
-    $scope.getSongIdByIndex = (index) =>
-      $scope.playlist[getSafeIndex(index, $scope.playlist.length)].id;
+    $scope.getSongIdByIndex = (index) => {
+      const songId =
+        $scope.playlist[getSafeIndex(index, $scope.playlist.length)].id;
+      return `${songId}_${index}`;
+    };
 
     $scope.refreshStage = () => {
+      if ($scope.playlist === undefined) {
+        return;
+      }
       const STAGED_LENGTH = 5;
       let i = $scope.currentIndex - 2;
       $scope.staged_playlist = [];
       while ($scope.staged_playlist.length < STAGED_LENGTH) {
-        $scope.staged_playlist.push(
-          $scope.playlist[getSafeIndex(i, $scope.playlist.length)]
-        );
+        const song = $scope.playlist[getSafeIndex(i, $scope.playlist.length)];
+        $scope.staged_playlist.push({ ...song, stageId: `${song.id}_${i}` });
         i += 1;
       }
     };

--- a/listen1.html
+++ b/listen1.html
@@ -4011,12 +4011,12 @@
                       <li ng-class="{
                         lipause:!isPlaying,
                         liplay:isPlaying,
-                        rotatecircl:song.id === currentPlaying.id,
-                        a:song.id === getSongIdByIndex(currentIndex-1),
-                        b:song.id === currentPlaying.id,
-                        c:song.id === getSongIdByIndex(currentIndex+1),
-                        def:song.id === getSongIdByIndex(currentIndex+2)||song.id === getSongIdByIndex(currentIndex-2)}" class="hid"
-                            id="song{{ song.id }}" ng-repeat="song in staged_playlist track by song.id" draggable="true">
+                        rotatecircl:song.stageId === getSongIdByIndex(currentIndex),
+                        a:song.stageId === getSongIdByIndex(currentIndex-1),
+                        b:song.stageId === getSongIdByIndex(currentIndex),
+                        c:song.stageId === getSongIdByIndex(currentIndex+1),
+                        def:song.stageId === getSongIdByIndex(currentIndex+2)||song.stageId === getSongIdByIndex(currentIndex-2)}" class="hid"
+                            id="song{{ song.id }}" ng-repeat="song in staged_playlist track by song.stageId" draggable="true">
                     <img
                     err-src="https://y.gtimg.cn/mediastyle/global/img/album_300.png"
                     ng-src="{{song.img_url.replace('/120/','/300/')}}?param=300y300" alt="">


### PR DESCRIPTION
修复播放列表小于5首歌时的问题

问题原因：之前小于5首歌时，采用的列表key重复导致了显示问题。修复后使用了song id和index结合的方式，可以在只有一首歌的时候同样可以生成不同的key。