### PR TITLE
remove ape and add web compatible formats

### DIFF
--- a/js/controller/navigation.js
+++ b/js/controller/navigation.js
@@ -652,7 +652,7 @@ angular.module('listenone').controller('NavigationController', [
             filters: [
               {
                 name: 'Music Files',
-                extensions: ['ape', 'flac', 'mp3', 'wav'],
+                extensions: ['flac', 'mp3', 'mp4', 'ogg', 'wav', 'webm'],
               },
             ],
           })


### PR DESCRIPTION
fix https://github.com/listen1/listen1_desktop/issues/837
Also, the Gpu load issue on play still exists, when the app is playing the Gpu usage surges from 1% to 30% on my Desktop with 2080, which means a nightmare on low-end laptops. The Gpu usage will drop when it's stopped or in the background.
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/32220948/190940328-ec011599-4c77-415a-9dcf-feeaf6d4efd4.png">
It seems that it's due to layer update, but I've tried disable some elements (like the circling cover) on the Playbar since they're the only element that are moving, but it didn't work. It seems that there's still something under the hood here.
Below is my complete perf log. 
[Profile-20220918T222159.zip](https://github.com/listen1/listen1_chrome_extension/files/9595821/Profile-20220918T222159.zip)
