### PR TITLE
fix: kuwo search api, play url api error

### DIFF
--- a/js/provider/kuwo.js
+++ b/js/provider/kuwo.js
@@ -1,6 +1,51 @@
 /* eslint-disable no-undef */
 /* eslint-disable no-unused-vars */
 /* global async getParameterByName isElectron */
+
+function h(t, e) {
+  // NOTICE: this function is from kuwo website, so eslint is skipped.
+  /* eslint-disable */
+  if (null == e || e.length <= 0)
+    return (
+      console.log('Please enter a password with which to encrypt the message.'),
+      null
+    );
+  for (var n = '', i = 0; i < e.length; i++) n += e.charCodeAt(i).toString();
+  var r = Math.floor(n.length / 5),
+    o = parseInt(
+      n.charAt(r) +
+        n.charAt(2 * r) +
+        n.charAt(3 * r) +
+        n.charAt(4 * r) +
+        n.charAt(5 * r)
+    ),
+    l = Math.ceil(e.length / 2),
+    c = Math.pow(2, 31) - 1;
+  if (o < 2)
+    return (
+      console.log(
+        'Algorithm cannot find a suitable hash. Please choose a different password. \nPossible considerations are to choose a more complex or longer password.'
+      ),
+      null
+    );
+  var d = Math.round(1e9 * Math.random()) % 1e8;
+  for (n += d; n.length > 10; )
+    n = (
+      parseInt(n.substring(0, 10)) + parseInt(n.substring(10, n.length))
+    ).toString();
+  n = (o * n + l) % c;
+  var h = '',
+    f = '';
+  for (i = 0; i < t.length; i++)
+    (f +=
+      (h = parseInt(t.charCodeAt(i) ^ Math.floor((n / c) * 255))) < 16
+        ? '0' + h.toString(16)
+        : h.toString(16)),
+      (n = (o * n + l) % c);
+  for (d = d.toString(16); d.length < 8; ) d = '0' + d;
+  return (f += d);
+}
+
 class kuwo {
   static forgeMD5(message) {
     const md = forge.md.sha1.create();
@@ -177,7 +222,7 @@ class kuwo {
       isRetryValue = isRetry;
     }
     const domain = 'https://www.kuwo.cn';
-    const name = 'Hm_token';
+    const name = 'Hm_Iuvt_cdb524f42f0ce19b169b8072123a4727';
 
     cookieGet(
       {
@@ -199,11 +244,12 @@ class kuwo {
   }
 
   static kw_cookie_get(url, callback) {
+    const name = 'Hm_Iuvt_cdb524f42f0ce19b169b8072123a4727';
     this.kw_get_token((token) => {
       axios
         .get(url, {
           headers: {
-            Cross: this.forgeMD5(token),
+            Secret: h(token, name),
           },
         })
         .then((response) => {
@@ -213,7 +259,7 @@ class kuwo {
               axios
                 .get(url, {
                   headers: {
-                    Cross: this.forgeMD5(token2),
+                    Secret: h(token2, name),
                   },
                 })
                 .then((res) => {
@@ -323,9 +369,9 @@ class kuwo {
       + `format=mp3&rid=${song_id}&response=url&type=convert_url3&br=128kmp3&from=web`;
     https://m.kuwo.cn/newh5app/api/mobile/v1/music/src/${song_id} */
 
-    const target_url = `http://www.kuwo.cn/api/v1/www/music/playUrl?mid=${song_id}&type=convert_url3&br=128kmp3`;
+    const target_url = `http://www.kuwo.cn/api/v1/www/music/playUrl?mid=${song_id}&type=music`;
 
-    axios.get(target_url).then((response) => {
+    this.kw_cookie_get(target_url, (response) => {
       const { data } = response;
 
       if (data && data.data && data.data.url) {


### PR DESCRIPTION
kuwo changed its api encrypt method, `Cross` in header now is not necessary. Instead of it, add `Secret` field in header and a cookie named `Hm_Iuvt_cdb524f42f0ce19b169b8072123a4727`.

And more, kuwo fixed api to fetch some vip music play url bug. So vip music play url request is rejected. Also, you need to use new method mentioned above to get accessed.