### PR TITLE
修复部分网易云歌曲的歌词显示问题

### DIFF
--- a/js/controller/play.js
+++ b/js/controller/play.js
@@ -430,7 +430,7 @@ angular.module('listenone').controller('PlayController', [
             };
             timeResult.push({
               content: line
-                .replace(/(\[\d{2,}:\d{2}\.\d{1,3}\])+/g, '')
+                .replace(/\[(\d{2,})\:(\d{2})(?:\.(\d{1,3}))?\]/g, '')
                 .replace(
                   /&(?:amp|lt|gt|quot|#39|apos);/g,
                   (match) => htmlUnescapes[match]

--- a/js/controller/play.js
+++ b/js/controller/play.js
@@ -430,7 +430,7 @@ angular.module('listenone').controller('PlayController', [
             };
             timeResult.push({
               content: line
-                .replace(timeRegResult[0], '')
+                .replace(/(\[\d{2,}:\d{2}\.\d{1,3}\])+/g, '')
                 .replace(
                   /&(?:amp|lt|gt|quot|#39|apos);/g,
                   (match) => htmlUnescapes[match]

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -551,7 +551,7 @@ class netease {
           let lrc = '';
           let tlrc = '';
           if (res_data.lrc != null) {
-            lrc = res_data.lrc.lyric;
+            lrc = res_data.lrc.lyric.replace(/(\[\d{2}:\d{2}\.\d{2}\]){2,}\n/g, '');
           }
           if (res_data.tlyric != null && res_data.tlyric.lyric != null) {
             // eslint-disable-next-line no-control-regex

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -551,7 +551,8 @@ class netease {
           let lrc = '';
           let tlrc = '';
           if (res_data.lrc != null) {
-            lrc = res_data.lrc.lyric.replace(/(\[\d{2}:\d{2}\.\d{2}\]){2,}\n/g, '');
+            lrc = res_data.lrc.lyric.replace(/(\[\d{2}:\d{2}\.\d{2}\]){2,}\n/g, '')
+                  .replace(/(\[\d{2}:\d{2}\.\d{2}\])(\[\d{2}:\d{2}\.\d{2}\])+/g, '$1');
           }
           if (res_data.tlyric != null && res_data.tlyric.lyric != null) {
             // eslint-disable-next-line no-control-regex

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -551,8 +551,7 @@ class netease {
           let lrc = '';
           let tlrc = '';
           if (res_data.lrc != null) {
-            lrc = res_data.lrc.lyric.replace(/(\[\d{2}:\d{2}\.\d{2}\]){2,}\n/g, '')
-                  .replace(/(\[\d{2}:\d{2}\.\d{2}\])(\[\d{2}:\d{2}\.\d{2}\])+/g, '$1');
+            lrc = res_data.lrc.lyric;
           }
           if (res_data.tlyric != null && res_data.tlyric.lyric != null) {
             // eslint-disable-next-line no-control-regex


### PR DESCRIPTION
具体表现在歌词中会莫名多出一整行多余的时间戳，比如[这首](https://music.163.com/#/song?id=28481751)和[这首](https://music.163.com/#/song?id=498549890)（以前还见过别的，不过想不起来了，就找到这两个，欢迎补充）

~~这问题挺奇怪的，多出来的时间轴似乎没什么具体含义，也不是每首歌都有，可能是以前系统升级导致的问题？~~ 才知道 LRC 格式是允许一行有多个时间轴的……定位了一下好像是 parseLyric 函数的问题

补充：
<https://music.163.com/#/song?id=4927987>
<https://music.163.com/#/song?id=26117510>
<https://music.163.com/#/song?id=4936675>