### PR TITLE
修复播放部分歌曲时播放控制失灵的问题(#1200)

### DIFF
--- a/js/player_thread.js
+++ b/js/player_thread.js
@@ -272,6 +272,7 @@
       if (!data.howl) {
         data.howl = new Howl({
           src: [self._media_uri_list[data.url || data.id]],
+          format: 'mp3', // bypass Howl checking url extension, issue #1200
           volume: 1,
           mute: self.muted,
           html5: true, // Force to HTML5 so that the audio can stream in (best for large files).
@@ -335,12 +336,8 @@
             });
             self.currentAudio.disabled = true;
             self.sendPlayingEvent('err');
-            for (let i = 0; i < self.playlist.length; i += 1) {
-              if (self.playlist[i].howl === self.currentHowl) {
-                self.playlist[i].howl = null;
-              }
-            }
-            self.currentHowl = null;
+            self.currentHowl.unload();
+            data.howl = null;
             delete self._media_uri_list[data.id];
           },
           onplayerror(id, err) {


### PR DESCRIPTION
1. 创建Howl对象时伪装文件格式为mp3，跳过Howl加载文件时检查url扩展名的功能
2. 删除失效Howl对象时不遍历整个播放列表，直接使用data.howl
3. 删除失效Howl对象时让Howl停止播放，避免出现无法控制的后台播放行为