### PR TITLE
fix: cookie not sent problem in desktop

### DIFF
--- a/js/provider/bilibili.js
+++ b/js/provider/bilibili.js
@@ -392,35 +392,19 @@ class bilibili {
         const cookieName = 'buvid3';
         const expire =
           (new Date().getTime() + 1e3 * 60 * 60 * 24 * 365 * 100) / 1000;
-        cookieGet(
+
+        cookieSet(
           {
             url: domain,
             name: cookieName,
+            value: '0',
+            expirationDate: expire,
+            sameSite: 'no_restriction',
           },
-          (cookie) => {
-            if (cookie == null) {
-              cookieSet(
-                {
-                  url: domain,
-                  name: cookieName,
-                  value: '0',
-                  expirationDate: expire,
-                },
-                () => {
-                  axios.get(target_url).then((response) => {
-                    const result = response.data.data.result.map((song) =>
-                      this.bi_convert_song2(song)
-                    );
-                    const total = response.data.data.numResults;
-                    return fn({
-                      result,
-                      total,
-                    });
-                  });
-                }
-              );
-            } else {
-              axios.get(target_url).then((response) => {
+          () => {
+            axios
+              .get(target_url, { withCredentials: true })
+              .then((response) => {
                 const result = response.data.data.result.map((song) =>
                   this.bi_convert_song2(song)
                 );
@@ -430,7 +414,6 @@ class bilibili {
                   total,
                 });
               });
-            }
           }
         );
       },

--- a/js/provider/netease.js
+++ b/js/provider/netease.js
@@ -160,46 +160,20 @@ class netease {
 
   static ne_ensure_cookie(callback) {
     const domain = 'https://music.163.com';
-    const nuidName = '_ntes_nuid';
-    const nnidName = '_ntes_nnid';
+    const cookieName = 'NMTID';
+    const expire =
+      (new Date().getTime() + 1e3 * 60 * 60 * 24 * 365 * 100) / 1000;
 
-    cookieGet(
+    cookieSet(
       {
         url: domain,
-        name: nuidName,
+        name: cookieName,
+        value: '0',
+        expirationDate: expire,
+        sameSite: 'no_restriction',
       },
-      (cookie) => {
-        if (cookie == null) {
-          const nuidValue = this._create_secret_key(32);
-          const nnidValue = `${nuidValue},${new Date().getTime()}`;
-          // netease default cookie expire time: 100 years
-          const expire =
-            (new Date().getTime() + 1e3 * 60 * 60 * 24 * 365 * 100) / 1000;
-
-          cookieSet(
-            {
-              url: domain,
-              name: nuidName,
-              value: nuidValue,
-              expirationDate: expire,
-            },
-            () => {
-              cookieSet(
-                {
-                  url: domain,
-                  name: nnidName,
-                  value: nnidValue,
-                  expirationDate: expire,
-                },
-                () => {
-                  callback(null);
-                }
-              );
-            }
-          );
-        } else {
-          callback(null);
-        }
+      () => {
+        callback(null);
       }
     );
   }
@@ -405,54 +379,56 @@ class netease {
     };
     return {
       success: (fn) => {
-        axios
-          .post(target_url, new URLSearchParams(req_data))
-          .then((response) => {
-            const { data } = response;
-            let result = [];
-            let total = 0;
-            if (searchType === '0') {
-              result = data.result.songs.map((song_info) => ({
-                id: `netrack_${song_info.id}`,
-                title: song_info.name,
-                artist: song_info.artists[0].name,
-                artist_id: `neartist_${song_info.artists[0].id}`,
-                album: song_info.album.name,
-                album_id: `nealbum_${song_info.album.id}`,
-                source: 'netease',
-                source_url: `https://music.163.com/#/song?id=${song_info.id}`,
-                img_url: song_info.album.picUrl,
-                // url: `netrack_${song_info.id}`,
-                url: !this.is_playable(song_info) ? '' : undefined,
-              }));
-              total = data.result.songCount;
-            } else if (searchType === '1') {
-              result = data.result.playlists.map((info) => ({
-                id: `neplaylist_${info.id}`,
-                title: info.name,
-                source: 'netease',
-                source_url: `https://music.163.com/#/playlist?id=${info.id}`,
-                img_url: info.coverImgUrl,
-                url: `neplaylist_${info.id}`,
-                author: info.creator.nickname,
-                count: info.trackCount,
-              }));
-              total = data.result.playlistCount;
-            }
+        this.ne_ensure_cookie(() => {
+          axios
+            .post(target_url, new URLSearchParams(req_data))
+            .then((response) => {
+              const { data } = response;
+              let result = [];
+              let total = 0;
+              if (searchType === '0') {
+                result = data.result.songs.map((song_info) => ({
+                  id: `netrack_${song_info.id}`,
+                  title: song_info.name,
+                  artist: song_info.artists[0].name,
+                  artist_id: `neartist_${song_info.artists[0].id}`,
+                  album: song_info.album.name,
+                  album_id: `nealbum_${song_info.album.id}`,
+                  source: 'netease',
+                  source_url: `https://music.163.com/#/song?id=${song_info.id}`,
+                  img_url: song_info.album.picUrl,
+                  // url: `netrack_${song_info.id}`,
+                  url: !this.is_playable(song_info) ? '' : undefined,
+                }));
+                total = data.result.songCount;
+              } else if (searchType === '1') {
+                result = data.result.playlists.map((info) => ({
+                  id: `neplaylist_${info.id}`,
+                  title: info.name,
+                  source: 'netease',
+                  source_url: `https://music.163.com/#/playlist?id=${info.id}`,
+                  img_url: info.coverImgUrl,
+                  url: `neplaylist_${info.id}`,
+                  author: info.creator.nickname,
+                  count: info.trackCount,
+                }));
+                total = data.result.playlistCount;
+              }
 
-            return fn({
-              result,
-              total,
-              type: searchType,
-            });
-          })
-          .catch(() =>
-            fn({
-              result: [],
-              total: 0,
-              type: searchType,
+              return fn({
+                result,
+                total,
+                type: searchType,
+              });
             })
-          );
+            .catch(() =>
+              fn({
+                result: [],
+                total: 0,
+                type: searchType,
+              })
+            );
+        });
       },
     };
   }


### PR DESCRIPTION
## Problem
After upgrade electron, search is not available for netease and bilibili for desktop app.

## Reason
It seems electron use more strict cookie access when make cross domain request. Cookie should set sameSite to no-restriction instead of lax to let request bring cookie in local.
And netease has change auth method as well, now NMTID cookie should be provided, but value is not checked.

## Solution
- Change cookie object sameSite field value to `no-restriction`
- Set netease NMTID cookie value

## Future work
- Deep investivate for cross domain cookie policy, because chrome browser has already showed warning for that. Maybe this method would not be working in the future.
- Netease NMTID fetched from site instead of fixed value.